### PR TITLE
Correctly install generated custom MD header

### DIFF
--- a/.github/workflows/mcg-ci.yml
+++ b/.github/workflows/mcg-ci.yml
@@ -17,6 +17,11 @@ jobs:
       run: cmake -B build -S .
     - name: build
       run: cmake --build build --parallel
+    - name: install
+      run: |
+        cmake --install build --prefix install
+        stat install/lib/libmetacg.so
+        stat install/include/metadata/CustomMD.h
 
   build-container:
     runs-on: ubuntu-latest

--- a/cmake/installRules.cmake
+++ b/cmake/installRules.cmake
@@ -16,6 +16,8 @@ install(
   DIRECTORY include/ "${PROJECT_BINARY_DIR}/graph/export/"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
   COMPONENT metacg_Development
+  FILES_MATCHING
+  PATTERN "*.h"
 )
 
 # Installation rule for the metacg library. Honestly, not sure what all this does. Following the example here:
@@ -74,6 +76,13 @@ install(
   EXPORT metacgTargets
   NAMESPACE metacg::
   DESTINATION "${metacg_INSTALL_CMAKEDIR}"
+  COMPONENT metacg_Development
+)
+
+# Install the generated CustomMD.h header
+install(
+  FILES ${PROJECT_BINARY_DIR}/graph/include/metadata/CustomMD.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/metadata
   COMPONENT metacg_Development
 )
 


### PR DESCRIPTION
We generate a custom header file `CustomMD.h` that includes all of the headers added to `metadata/custom`. 
Previously, this header was not copied to the install directory. 
This patch correctly installs the generated header and excludes the `CustomMD.h.in` template file from the installation. 