### PR TITLE
Add top-level 'metacg' folder to header install path

### DIFF
--- a/.github/workflows/mcg-ci.yml
+++ b/.github/workflows/mcg-ci.yml
@@ -21,7 +21,7 @@ jobs:
       run: |
         cmake --install build --prefix install
         stat install/lib/libmetacg.so
-        stat install/include/metadata/CustomMD.h
+        stat install/include/metacg/metadata/CustomMD.h
 
   build-container:
     runs-on: ubuntu-latest

--- a/cmake/installRules.cmake
+++ b/cmake/installRules.cmake
@@ -18,7 +18,7 @@ install(
   COMPONENT metacg_Development
   FILES_MATCHING
   PATTERN "*.h"
-        PATTERN "*.hpp"
+  PATTERN "*.hpp"
 )
 
 # Installation rule for the metacg library. Honestly, not sure what all this does. Following the example here:

--- a/cmake/installRules.cmake
+++ b/cmake/installRules.cmake
@@ -33,7 +33,7 @@ install(
   ARCHIVE #
           COMPONENT metacg_Development
   INCLUDES #
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/metacg"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
 )
 
 # Call helper function to "generate" a metacgConfigVersion file

--- a/cmake/installRules.cmake
+++ b/cmake/installRules.cmake
@@ -14,10 +14,11 @@ set(package metacg)
 # We put the export file there. We currently don't really use the export file (and I'm unsure if we should)
 install(
   DIRECTORY include/ "${PROJECT_BINARY_DIR}/graph/export/"
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/metacg"
   COMPONENT metacg_Development
   FILES_MATCHING
   PATTERN "*.h"
+        PATTERN "*.hpp"
 )
 
 # Installation rule for the metacg library. Honestly, not sure what all this does. Following the example here:
@@ -32,7 +33,7 @@ install(
   ARCHIVE #
           COMPONENT metacg_Development
   INCLUDES #
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/metacg"
 )
 
 # Call helper function to "generate" a metacgConfigVersion file
@@ -67,7 +68,7 @@ install(
 # Install config.h
 install(
   FILES "${PROJECT_BINARY_DIR}/config.h"
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/metacg"
   COMPONENT metacg_Development
 )
 
@@ -82,7 +83,7 @@ install(
 # Install the generated CustomMD.h header
 install(
   FILES ${PROJECT_BINARY_DIR}/graph/include/metadata/CustomMD.h
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/metadata
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/metacg/metadata
   COMPONENT metacg_Development
 )
 

--- a/graph/CMakeLists.txt
+++ b/graph/CMakeLists.txt
@@ -86,7 +86,7 @@ generate_export_header(
   BASE_NAME
   metacg
   EXPORT_FILE_NAME
-  export/metacg/metacg_export.hpp
+  export/metacg_export.hpp
 )
 
 set_target_properties(


### PR DESCRIPTION
This inserts a top-level `metacg` directory to the installed include tree.

