### PR TITLE
[NFC] Add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to make json work with newer CMake

### DIFF
--- a/.github/workflows/mcg-ci.yml
+++ b/.github/workflows/mcg-ci.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: cmake
-      run: cmake -B build -S .
+      run: -DCMAKE_POLICY_VERSION_MINIMUM=3.5 cmake -B build -S .
     - name: build
       run: cmake --build build --parallel
     - name: install


### PR DESCRIPTION
The github CI is broken, because compatibility with CMake >3.5 was removed in the latest CMake release. This adds  ` -DCMAKE_POLICY_VERSION_MINIMUM=3.5` to the CI build as  a workaround.