### PR TITLE
Remove unnecessary error reporting in cgvalidate tests; fix typo from cgverify to cgvalidate

### DIFF
--- a/cgcollector/test/integration/cgvalidate/base.sh
+++ b/cgcollector/test/integration/cgvalidate/base.sh
@@ -1,6 +1,6 @@
 function report {
   echo -e "\n[ --------------------------------- ] \n" >> "$logFile"
-  echo "Running cgverify Integration Test $testNo | $failStr"
+  echo "Running cgvalidate Integration Test $testNo | $failStr"
 }
 
 function failed {

--- a/cgcollector/test/integration/cgvalidate/cgvalidate-run.sh
+++ b/cgcollector/test/integration/cgvalidate/cgvalidate-run.sh
@@ -50,47 +50,47 @@ fi
 #general
 ## wrong input files
 echo "Invocation: $executable -i $inputDir/general/0001.cubex -c $inputDir/general/0001.cubex" >> $logFile
-$executable -i $inputDir/general/0001.cubex -c $inputDir/general/0001.cubex >> $logFile
+$executable -i $inputDir/general/0001.cubex -c $inputDir/general/0001.cubex >> $logFile 2>&1
 checkErrorCode 2
 echo "Invocation: $executable -i $inputDir/general/0001.ipcg -c $inputDir/general/0001.ipcg" >> $logFile
-$executable -i $inputDir/general/0001.ipcg -c $inputDir/general/0001.ipcg >> $logFile
+$executable -i $inputDir/general/0001.ipcg -c $inputDir/general/0001.ipcg >> $logFile  2>&1
 checkErrorCode 3
 
 ## missing edges
 echo "Invocation: $executable -i $inputDir/general/0001_missedcallee.ipcg -c $inputDir/general/0001.cubex" >> $logFile
-$executable -i $inputDir/general/0001_missedcallee.ipcg -c $inputDir/general/0001.cubex >> $logFile
+$executable -i $inputDir/general/0001_missedcallee.ipcg -c $inputDir/general/0001.cubex >> $logFile  2>&1
 checkErrorCode 1
 echo "Invocation: $executable -i $inputDir/general/0001_missedparent.ipcg -c $inputDir/general/0001.cubex" >> $logFile
-$executable -i $inputDir/general/0001_missedparent.ipcg -c $inputDir/general/0001.cubex >> $logFile
+$executable -i $inputDir/general/0001_missedparent.ipcg -c $inputDir/general/0001.cubex >> $logFile  2>&1
 checkErrorCode 1
 echo "Invocation: $executable -i $inputDir/general/0001_missedboth.ipcg -c $inputDir/general/0001.cubex" >> $logFile
-$executable -i $inputDir/general/0001_missedboth.ipcg -c $inputDir/general/0001.cubex >> $logFile
+$executable -i $inputDir/general/0001_missedboth.ipcg -c $inputDir/general/0001.cubex >> $logFile  2>&1
 checkErrorCode 1
 
 ## successfull run
 echo "Invocation $executable -i $inputDir/general/0001.ipcg -c $inputDir/general/0001.cubex" >> $logFile
-$executable -i $inputDir/general/0001.ipcg -c $inputDir/general/0001.cubex >> $logFile
+$executable -i $inputDir/general/0001.ipcg -c $inputDir/general/0001.cubex >> $logFile 2>&1
 checkErrorCode 0
 
 #virtual
 echo "Invocation: $executable -i $inputDir/virtual/exp1.ipcg -c $inputDir/virtual/exp1.cubex" >> $logFile
-$executable -i $inputDir/virtual/exp1.ipcg -c $inputDir/virtual/exp1.cubex >> $logFile
+$executable -i $inputDir/virtual/exp1.ipcg -c $inputDir/virtual/exp1.cubex >> $logFile  2>&1
 checkErrorCode 0
 echo "Invocation: $executable -i $inputDir/virtual/exp2.ipcg -c $inputDir/virtual/exp2.cubex" >> $logFile
-$executable -i $inputDir/virtual/exp2.ipcg -c $inputDir/virtual/exp2.cubex >> $logFile
+$executable -i $inputDir/virtual/exp2.ipcg -c $inputDir/virtual/exp2.cubex >> $logFile  2>&1
 checkErrorCode 0
 echo "Invocation: $executable -i $inputDir/virtual/exp3.ipcg -c $inputDir/virtual/exp3.cubex" >> $logFile
-$executable -i $inputDir/virtual/exp3.ipcg -c $inputDir/virtual/exp3.cubex >> $logFile
+$executable -i $inputDir/virtual/exp3.ipcg -c $inputDir/virtual/exp3.cubex >> $logFile  2>&1
 checkErrorCode 0
 
 #fix
 echo "Invocation: $executable -i $inputDir/fix/miss.ipcg -c $inputDir/fix/0001.cubex -p" >> $logFile
-$executable -i $inputDir/fix/miss.ipcg -c $inputDir/fix/0001.cubex -p -o $inputDir/fix/miss.ipcg.patched-${CI_CONCURRENT_ID} >> $logFile
-$executable -i $inputDir/fix/miss.ipcg.patched-${CI_CONCURRENT_ID} -c $inputDir/fix/0001.cubex >> $logFile
+$executable -i $inputDir/fix/miss.ipcg -c $inputDir/fix/0001.cubex -p -o $inputDir/fix/miss.ipcg.patched-${CI_CONCURRENT_ID} >> $logFile 2>&1
+$executable -i $inputDir/fix/miss.ipcg.patched-${CI_CONCURRENT_ID} -c $inputDir/fix/0001.cubex >> $logFile 2>&1
 checkErrorCode 0
 echo "Invocation: $executable -i $inputDir/fixvirtual/miss.ipcg -c $inputDir/fixvirtual/exp1.cubex -p" >> $logFile
-$executable -i $inputDir/fixvirtual/miss.ipcg -c $inputDir/fixvirtual/exp1.cubex -p -o $inputDir/fixvirtual/miss.ipcg.patched-${CI_CONCURRENT_ID}>> $logFile
-$executable -i $inputDir/fixvirtual/miss.ipcg.patched-${CI_CONCURRENT_ID} -c $inputDir/fixvirtual/exp1.cubex >> $logFile
+$executable -i $inputDir/fixvirtual/miss.ipcg -c $inputDir/fixvirtual/exp1.cubex -p -o $inputDir/fixvirtual/miss.ipcg.patched-${CI_CONCURRENT_ID}>> $logFile 2>&1
+$executable -i $inputDir/fixvirtual/miss.ipcg.patched-${CI_CONCURRENT_ID} -c $inputDir/fixvirtual/exp1.cubex >> $logFile 2>&1
 checkErrorCode 0
 
 


### PR DESCRIPTION
Cgvalidate uses std::cerr as output stream for errors.
These are not captured in the logfile.
This PR also redirects std::cerr to the logfile in the cgvalidate integration tests.

It also removes the use of the old name cgverify from the startup message in favor of cgvalidate