### PR TITLE
Rework build_submodules.sh and handle different packaged llvm versions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.venv/
+build/
+extern/

--- a/.github/workflows/mcg-ci.yml
+++ b/.github/workflows/mcg-ci.yml
@@ -52,32 +52,32 @@ jobs:
         uses: addnab/docker-run-action@v3
         with: 
           image: metacg-devel:latest
-          run: /opt/metacg/metacg/build/graph/test/unit/libtests
+          run: /opt/metacg/build/graph/test/unit/libtests
       - name: Run PGIS library tests 
         uses: addnab/docker-run-action@v3
         with: 
           image: metacg-devel:latest
-          run: /opt/metacg/metacg/build/pgis/test/unit/pgistests
+          run: /opt/metacg/build/pgis/test/unit/pgistests
       - name: Run target collector tests 
         uses: addnab/docker-run-action@v3
         with: 
           image: metacg-devel:latest
           run: |
-            cd /opt/metacg/metacg/graph/test/integration/TargetCollector
+            cd /opt/metacg/graph/test/integration/TargetCollector
             ./TestRunner.sh
       - name: Run call graph merge tests
         uses: addnab/docker-run-action@v3
         with: 
           image: metacg-devel:latest
           run: |
-            cd /opt/metacg/metacg/graph/test/integration/CallgraphMerge
+            cd /opt/metacg/graph/test/integration/CallgraphMerge
             ./MergeTestRunner.sh
       - name: Run cgcollector tests
         uses: addnab/docker-run-action@v3
         with: 
           image: metacg-devel:latest
           run: |
-            cd /opt/metacg/metacg/cgcollector/test
+            cd /opt/metacg/cgcollector/test
             bash run_format_one_test.sh 
             bash run_format_two_test.sh 
       - name: Run cgvalidate tests
@@ -85,5 +85,5 @@ jobs:
         with: 
           image: metacg-devel:latest
           run: |
-            cd /opt/metacg/metacg/cgcollector/test/integration
+            cd /opt/metacg/cgcollector/test/integration
             ./runner.sh build

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 build/
 install/
 extern/
+.venv/
 
 .idea/
 .cache/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,8 +76,8 @@ mcg-container:
   script:
     - podman login ${CI_REGISTRY} -u ${CI_REGISTRY_USER} -p ${CI_REGISTRY_PASSWORD}
     - podman build -t metacg:$CI_PIPELINE_ID -f container/metacg .
-    - podman run --cgroupns=host --rm -t metacg:$CI_PIPELINE_ID /opt/metacg/metacg/build/pgis/test/unit/pgistests
-    - podman run --cgroupns=host --rm -t metacg:$CI_PIPELINE_ID /opt/metacg/metacg/build/graph/test/unit/libtests
+    - podman run --cgroupns=host --rm -t metacg:$CI_PIPELINE_ID /opt/metacg/build/pgis/test/unit/pgistests
+    - podman run --cgroupns=host --rm -t metacg:$CI_PIPELINE_ID /opt/metacg/build/graph/test/unit/libtests
 
 
 # Stage: build

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ $> cmake --install build
 
 You can configure MetaCG to also build CGCollector and PGIS.
 This requires additional dependencies.
-Clang/LLVM (in a supported version) and the Cube library are assumed to be available on the system.
-Extra-P can be built using the `build_submodules.sh` script provided in the repository, though the script is not tested outside of our CI system.
-It builds and installs Extra-P into `./deps/src` and `./deps/install`, respectively.
+Clang/LLVM (in a supported version) are assumed to be available on the system.
+Extra-P and Cube library can be built using the `build_submodules.sh` script provided in the repository, though the script is not tested outside of our CI system.
+It builds and installs the dependencies into `./extern`.
 
 ```{.sh}
 $> ./build_submodules.sh
@@ -66,7 +66,14 @@ Change the `CMAKE_INSTALL_PREFIX` to where you want your MetaCG installation to 
 
 ```{.sh}
 # To build the MetaCG library w/ PGIS and CGCollector
-$> cmake -S . -B build -DCMAKE_INSTALL_PREFIX=/where/to/install -DMETACG_BUILD_CGCOLLECTOR=ON -DCUBE_LIB=$(dirname $(which cube_info))/../lib -DCUBE_INCLUDE=$(dirname $(which cube_info))/../include/cubelib -DEXTRAP_INCLUDE=./extern/src/extrap/extrap-3.0/include -DEXTRAP_LIB=./extern/install/extrap/lib
+$> extinstalldir=./extern cmake -S . -B build \
+  -DCMAKE_INSTALL_PREFIX=/where/to/install \
+  -DCMAKE_INSTALL_PREFIX="$extinstalldir/metacg" \
+  -DCUBE_LIB="$extinstalldir/cubelib/lib" \
+  -DCUBE_INCLUDE="$extinstalldir/cubelib/include/cubelib" \
+  -DEXTRAP_INCLUDE="$extinstalldir/extrap/include" \
+  -DEXTRAP_LIB="$extinstalldir/extrap/lib" \
+  -DMETACG_BUILD_CGCOLLECTOR=ON
 $> cmake --build build --parallel
 # Installation installs CGCollector, CGMerge, CGValidate, PGIS
 $> cmake --install build

--- a/build_submodules.sh
+++ b/build_submodules.sh
@@ -1,80 +1,119 @@
-#! /usr/bin/env bash
+#!/usr/bin/env bash
 #"""
 # File: build_submodules.sh
 # License: Part of the MetaCG project. Licensed under BSD 3 clause license. See LICENSE.txt file at https://github.com/tudasc/MetaCG/LICENSE.txt
 # Description: Helper script to build the git submodules useed in MetaCG.
 #"""
+set -euo pipefail
 
-scriptdir="$(
-  cd "$(dirname "$0")"
-  pwd -P
-)"
-mkdir -p $scriptdir/extern/src
-mkdir -p $scriptdir/extern/install
-extsourcedir=$scriptdir/extern/src
-extinstalldir=$scriptdir/extern/install
+function log()
+{
+  echo "[MetaCG] $1"
+}
+
+function err_exit()
+{
+  echo "[MetaCG] Error: $1" >&2
+  exit 1
+}
+
+# python version
+set +e
+python_bin=""
+for cmd in python3.8 python3.9 python3.10 python3; do
+  if command -v "$cmd" >/dev/null 2>&1; then
+    python_bin="$cmd"
+    break
+  fi
+done
+set -e
+
+scriptdir="$(cd "$(dirname "$0")" && pwd -P)"
+extsourcedir="$scriptdir/extern/src"
+extinstalldir="$scriptdir/extern/install"
+venv_dir="$scriptdir/.venv"
+
+mkdir -p "$extsourcedir" "$extinstalldir"
 
 # TODO Make this actually working better!
 # Allow configure options (here for Score-P, bc I want to build it w/o MPI)
-parallel_jobs="$1"
-add_flags="$2"
+parallel_jobs="${1:-$(nproc)}"
+add_flags="${2:-}"
+
+log "Setting up python venv"
+if [ -f "$venv_dir/bin/activate" ]; then
+  log "python venv already set up. Skipping."
+  source "$venv_dir/bin/activate" || err_exit "Activating python venv failed"
+else
+  "$python_bin" -m venv "$venv_dir" || err_exit "Creating python venv failed"
+  source "$venv_dir/bin/activate" || err_exit "Activating python venv failed"
+  pip install --upgrade pip
+  pip install PyQt5 matplotlib || err_exit "Installing Extra-P dependencies failed."
+fi
+
+log "Building cubelib for Extra-P"
+if [ -f "$extinstalldir/cubelib/bin/cubelib-config" ]; then
+  log "cubelib is already built. Skipping."
+else
+  cubelib_dir="$extsourcedir/cubelib"
+  cubelib_tarball="$cubelib_dir/cubelib-4.5.tar.gz"
+  cubelib_build="$cubelib_dir/cubelib-4.5/build"
+  mkdir -p "$cubelib_dir"
+
+  if [ ! -f "$cubelib_tarball" ]; then
+    log "Downloading cubelib"
+    wget -O "$cubelib_tarball" "http://apps.fz-juelich.de/scalasca/releases/cube/4.5/dist/cubelib-4.5.tar.gz" || err_exit "cubelib download failed"
+  fi
+
+  tar -xzf "$cubelib_tarball" -C "$cubelib_dir"
+  rm -rf "$cubelib_build"
+  mkdir -p "$cubelib_build"
+
+  (
+    cd "$cubelib_build"
+    ../configure --prefix="$extinstalldir/cubelib" || err_exit "Configuring cubelib failed"
+    make -j "$parallel_jobs" || err_exit "Building cubelib failed"
+    make install || err_exit "Installing cubelib failed"
+  )
+
+  log "cubelib built and installed successfully"
+fi
 
 # Extra-P (https://www.scalasca.org/software/extra-p/download.html)
-echo "[MetaCG] Building Extra-P (for PIRA II modeling)"
-echo "[MetaCG] Getting prerequisites ..."
-pip3 show PyQt5
-PYQT5_INSTALLED=$?
-if [ $PYQT5_INSTALLED -eq 1 ]; then
-  pip3 install --user PyQt5
-fi
-pip3 show matplotlib
-MATPLOTLIB_INSTALLED=$?
-if [ $MATPLOTLIB_INSTALLED -eq 1 ]; then
-  pip3 install --user matplotlib
-fi
-if [ $? -ne 0 ]; then
-  echo "[MetaCG] Installing Extra-P dependencies failed."
-  exit 1
-fi
+log "Building Extra-P (for PIRA II modeling)"
+if [ -f "$extinstalldir/extrap/bin/extrap" ]; then
+  log "Extra-P is already built. Skipping."
+else
+  extrap_dir="$extsourcedir/extrap"
+  extrap_tarball="$extrap_dir/extrap-3.0.tar.gz"
+  extrap_build="$extrap_dir/extrap-3.0/build"
+  mkdir -p "$extrap_dir"
 
-mkdir -p $extsourcedir/extrap
-cd $extsourcedir/extrap
+  if [ ! -f "$extrap_tarball" ]; then
+    log "Downloading Extra-P"
+    wget -O "$extrap_tarball" "http://apps.fz-juelich.de/scalasca/releases/extra-p/extrap-3.0.tar.gz" || err_exit "Download failed"
+  fi
 
-# TODO check if extra-p is already there, if so, no download / no build?
-if [ ! -f "extrap-3.0.tar.gz" ]; then
-  echo "[MetaCG] Downloading and building Extra-P"
-  wget http://apps.fz-juelich.de/scalasca/releases/extra-p/extrap-3.0.tar.gz
-fi
-tar xzf extrap-3.0.tar.gz
-cd ./extrap-3.0
-rm -rf build
-mkdir build && cd build
+  tar -xzf "$extrap_tarball" -C "$extrap_dir"
+  rm -rf "$extrap_build"
+  mkdir -p "$extrap_build"
 
-# python3-config should be the preferred way to get the python include directory,
-# but at least with python 3.9 on ubuntu it is a bit buggy and some distributions don't support it at all
-pythonheader=$(python3 -c "from sysconfig import get_paths; print(get_paths()[\"include\"])")
-if [ -z $pythonheader ]; then
-  echo "[MetaCG] Python header not found."
-  exit 1
-fi
-echo "[MetaCG] Found Python.h at " $pythonheader
-../configure --prefix=$extinstalldir/extrap CPPFLAGS=-I$pythonheader >/dev/null 2>&1
-if [ $? -ne 0 ]; then
-  echo "[MetaCG] Configuring Extra-P failed."
-  exit 1
-fi
+  # python3-config should be the preferred way to get the python include directory,
+  # but at least with python 3.9 on ubuntu it is a bit buggy and some distributions don't support it at all
+  pythonheader=$("$python_bin" -c "from sysconfig import get_paths; print(get_paths().get('include', ''))")
+  [ -z "$pythonheader" ] && err_exit "Python header not found."
+  log "Found Python.h at $pythonheader"
 
-make -j $parallel_jobs >/dev/null 2>&1
-if [ $? -ne 0 ]; then
-  echo "[MetaCG] Building Extra-P failed."
-  exit 1
-fi
+  (
+    cd "$extrap_build"
+    export PATH="$extinstalldir/cubelib/bin:$PATH"
+    ../configure --prefix="$extinstalldir/extrap" CPPFLAGS="-I$pythonheader" || err_exit "Configuring Extra-P failed"
+    make -j "$parallel_jobs" || err_exit "Building Extra-P failed"
+    make install || err_exit "Installing Extra-P failed"
+  )
 
-make install >/dev/null 2>&1
-if [ $? -ne 0 ]; then
-  echo "[MetaCG] Installing Extra-P failed."
-  exit 1
-fi
+  mkdir -p "$extinstalldir/extrap/include"
+  cp "$extrap_dir/extrap-3.0/include/"* "$extinstalldir/extrap/include"
 
-mkdir $extinstalldir/extrap/include
-cp $extsourcedir/extrap/extrap-3.0/include/* $extinstalldir/extrap/include
+  log "Extra-P built and installed successfully"
+fi

--- a/cmake/ClangLLVM.cmake
+++ b/cmake/ClangLLVM.cmake
@@ -50,15 +50,26 @@ function(add_clang target)
   # clang specified as system lib to suppress all warnings from clang headers
   target_include_directories(${target} SYSTEM PUBLIC ${CLANG_INCLUDE_DIRS})
 
-  target_link_libraries(
-    ${target}
-    PUBLIC clangTooling
-           clangFrontend
-           clangSerialization
-           clangAST
-           clangBasic
-           clangIndex
+  # Try clang-cpp first, fallback to individual libs
+  find_library(
+    CLANG_CPP_LIB clang-cpp
+    PATHS ${LLVM_LIBRARY_DIR}
+    NO_DEFAULT_PATH
   )
+  if(CLANG_CPP_LIB)
+    target_link_libraries(${target} PUBLIC clang-cpp)
+  else()
+    target_link_libraries(
+      ${target}
+      PUBLIC clangTooling
+             clangFrontend
+             clangSerialization
+             clangAST
+             clangBasic
+             clangIndex
+    )
+  endif()
+
   if(LLVM_LINK_LLVM_DYLIB)
     target_link_libraries(${target} PUBLIC LLVM)
   else()

--- a/container/base
+++ b/container/base
@@ -4,7 +4,7 @@ WORKDIR /opt/metacg
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update -y && apt-get upgrade -y && apt-get install -y gcc g++ gdb cmake python3 apt-utils wget gnupg qt5-default git autoconf automake libtool zlib1g-dev zlib1g vim unzip python3-pip python3-pytest python3-pytest-cov openmpi-bin openmpi-common bison flex python2 bear
+RUN apt-get update -y && apt-get upgrade -y && apt-get install -y gcc g++ gdb cmake python3 apt-utils wget gnupg qt5-default git autoconf automake libtool zlib1g-dev zlib1g vim unzip python3-pip python3-pytest python3-pytest-cov python3-venv openmpi-bin openmpi-common bison flex python2 bear
 
 RUN pip3 install -U pip
 

--- a/container/full-build
+++ b/container/full-build
@@ -11,48 +11,37 @@ RUN apt-get update -y && \
         cmake python3 apt-utils wget gnupg \
         qtbase5-dev git autoconf automake \
         libtool zlib1g-dev zlib1g vim unzip \
-        python3-pip python3-pytest python3-pytest-cov \
+        python3-pip python3-venv python3-pytest python3-pytest-cov \
         openmpi-bin openmpi-common bison flex bear \
         lsb-release wget software-properties-common \
         python3-matplotlib python3-pyqt5 ninja-build
-
 
 RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
     add-apt-repository -y 'deb http://apt.llvm.org/bookworm/  llvm-toolchain-bookworm-18 main' && \
     add-apt-repository -y 'deb http://apt.llvm.org/bookworm/  llvm-toolchain-bookworm-18 main' && \
     apt-get update && \
     apt-get install -y libllvm18 llvm-18 llvm-18-dev llvm-18-runtime \
-        clang-18 clang-tools-18 libclang-common-18-dev libclang-18-dev libclang1-18 
+        clang-18 clang-tools-18 libclang-common-18-dev libclang-18-dev libclang1-18
 RUN bash -c "ln -s $(which clang-18) /usr/bin/clang" && \
     bash -c "ln -s $(which clang++-18) /usr/bin/clang++" && \
     bash -c "ln -s $(which llvm-config-18) /usr/bin/llvm-config"
 
 
-RUN mkdir -p deps/install && \
-      cd deps && \
-      wget http://apps.fz-juelich.de/scalasca/releases/cube/4.5/dist/cubelib-4.5.tar.gz && \
-      mkdir cubelib && \
-      cd cubelib && \
-      tar xzf ../cubelib-4.5.tar.gz && cd cubelib-4.5 && \
-      ./configure --prefix=/opt/metacg/extern/install/cubelib && \
-      make -j $(nproc) && \
-      make install
+ARG extinstalldir=/opt/metacg/extern/install
+ENV EXTINSTALLDIR=$extinstalldir
 
-RUN mkdir metacg
+COPY ./build_submodules.sh /opt/metacg
 
-COPY ./build_submodules.sh /opt/metacg/metacg
+RUN ./build_submodules.sh $(nproc)
 
-RUN cd metacg && \
-    PATH=/opt/metacg/extern/install/cubelib/bin:$PATH ./build_submodules.sh $(nproc)
+COPY . /opt/metacg
 
-COPY . /opt/metacg/metacg
-
-RUN cd metacg && cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug \
+RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug \
       -DCMAKE_INSTALL_PREFIX=/tmp/metacg \
-      -DCUBE_LIB=/opt/metacg/extern/install/cubelib/lib \
-      -DCUBE_INCLUDE=/opt/metacg/extern/install/cubelib/include/cubelib \
-      -DEXTRAP_INCLUDE=./extern/install/extrap/include \
-      -DEXTRAP_LIB=./extern/install/extrap/lib \
+      -DCUBE_LIB=$EXTINSTALLDIR/cubelib/lib \
+      -DCUBE_INCLUDE=$EXTINSTALLDIR/cubelib/include/cubelib \
+      -DEXTRAP_INCLUDE=$EXTINSTALLDIR/extrap/include \
+      -DEXTRAP_LIB=$EXTINSTALLDIR/extrap/lib \
       -DMETACG_BUILD_PGIS=ON \
       -DMETACG_BUILD_CGCOLLECTOR=ON \
       -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON && \

--- a/container/metacg
+++ b/container/metacg
@@ -2,31 +2,21 @@ FROM registry.git.rwth-aachen.de/tuda-sc/projects/metacg/base:latest
 
 WORKDIR /opt/metacg
 
-RUN mkdir -p deps/install && \
-      cd deps && \
-      wget http://apps.fz-juelich.de/scalasca/releases/cube/4.5/dist/cubelib-4.5.tar.gz && \
-      mkdir cubelib && \
-      cd cubelib && \
-      tar xzf ../cubelib-4.5.tar.gz && cd cubelib-4.5 && \
-      ./configure --prefix=/opt/metacg/extern/install/cubelib && \
-      make -j $(nproc) && \
-      make install
+ARG extinstalldir=/opt/metacg/extern/install
+ENV EXTINSTALLDIR=$extinstalldir
 
-RUN mkdir metacg
+COPY ./build_submodules.sh /opt/metacg
 
-COPY ./build_submodules.sh /opt/metacg/metacg
+RUN ./build_submodules.sh $(nproc)
 
-RUN cd metacg && \
-    PATH=/opt/metacg/extern/install/cubelib/bin:$PATH ./build_submodules.sh $(nproc)
+COPY . /opt/metacg
 
-COPY . /opt/metacg/metacg
-
-RUN cd metacg && cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug \
+RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug \
       -DCMAKE_INSTALL_PREFIX=/tmp/metacg \
-      -DCUBE_LIB=/opt/metacg/extern/install/cubelib/lib \
-      -DCUBE_INCLUDE=/opt/metacg/extern/install/cubelib/include/cubelib \
-      -DEXTRAP_INCLUDE=./extern/install/extrap/include \
-      -DEXTRAP_LIB=./extern/install/extrap/lib \
+      -DCUBE_LIB=$EXTINSTALLDIR/cubelib/lib \
+      -DCUBE_INCLUDE=$EXTINSTALLDIR/cubelib/include/cubelib \
+      -DEXTRAP_INCLUDE=$EXTINSTALLDIR/extrap/include \
+      -DEXTRAP_LIB=$EXTINSTALLDIR/extrap/lib \
       -DMETACG_BUILD_PGIS=ON \
       -DMETACG_BUILD_CGCOLLECTOR=ON \
       -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON && \


### PR DESCRIPTION
Reopen PR because development has shifted to this repo.

Original PR-Message:

I had some trouble building this project. So I improved/rewrote the build_submodules.sh script to make it more useful outside the CI-Pipeline. And some distros, like arch, package LLVM differently. So I also updated the cmake files to check for that case.

What I did:

- the script now also downloads and build cubelib
- python venv. Because most modern distros don't allow installing python packages globally through pip anymore.
- updated the container files to new script behavior.
- updated README.md
- tested full-build container file. Works.