### PR TITLE
Improve CMake setup for linking cubelib

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,8 +89,7 @@ build-mcg-no-tests:
     - module load clang/$LLVM
     - cmake -S . -B $MCG_BUILD-no-tests -G Ninja -DCMAKE_BUILD_TYPE=Debug 
         -DCMAKE_INSTALL_PREFIX=/tmp/metacg/$MCG_BUILD-no-tests
-        -DCUBE_LIB=$(dirname $(which cube_info))/../lib 
-        -DCUBE_INCLUDE=$(dirname $(which cube_info))/../include/cubelib
+        -DCUBE_DIR=$(dirname $(which cube_info))/..
         -DEXTRAP_INCLUDE=./extern/install/extrap/include 
         -DEXTRAP_LIB=./extern/install/extrap/lib 
         -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON
@@ -106,8 +105,7 @@ build-mcg-stripped-all:
     - module load clang/$LLVM
     - cmake -S . -B $MCG_BUILD-no-all -G Ninja -DCMAKE_BUILD_TYPE=Debug 
         -DCMAKE_INSTALL_PREFIX=/tmp/metacg/$MCG_BUILD-dflt
-        -DCUBE_LIB=$(dirname $(which cube_info))/../lib 
-        -DCUBE_INCLUDE=$(dirname $(which cube_info))/../include/cubelib
+        -DCUBE_DIR=$(dirname $(which cube_info))/..
         -DEXTRAP_INCLUDE=./extern/install/extrap/include 
         -DEXTRAP_LIB=./extern/install/extrap/lib 
         -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON
@@ -122,8 +120,7 @@ build-mcg-stripped-pgis:
     - module load clang/$LLVM
     - cmake -S . -B $MCG_BUILD-no-cgcollector -G Ninja -DCMAKE_BUILD_TYPE=Debug
       -DCMAKE_INSTALL_PREFIX=/tmp/metacg/$MCG_BUILD-w_pgis
-      -DCUBE_LIB=$(dirname $(which cube_info))/../lib
-      -DCUBE_INCLUDE=$(dirname $(which cube_info))/../include/cubelib
+      -DCUBE_DIR=$(dirname $(which cube_info))/..
       -DEXTRAP_INCLUDE=./extern/install/extrap/include
       -DEXTRAP_LIB=./extern/install/extrap/lib
       -DMETACG_BUILD_PGIS=ON
@@ -139,8 +136,7 @@ build-mcg-stripped-cgcollector:
     - module load clang/$LLVM
     - cmake -S . -B $MCG_BUILD-no-pgis -G Ninja -DCMAKE_BUILD_TYPE=Debug
       -DCMAKE_INSTALL_PREFIX=/tmp/metacg/$MCG_BUILD-w_cgcollector
-      -DCUBE_LIB=$(dirname $(which cube_info))/../lib
-      -DCUBE_INCLUDE=$(dirname $(which cube_info))/../include/cubelib
+      -DCUBE_DIR=$(dirname $(which cube_info))/..
       -DEXTRAP_INCLUDE=./extern/install/extrap/include
       -DEXTRAP_LIB=./extern/install/extrap/lib
       -DMETACG_BUILD_CGCOLLECTOR=ON
@@ -156,8 +152,7 @@ build-mcg:
     - module load clang/$LLVM
     - cmake -S . -B $MCG_BUILD -G Ninja -DCMAKE_BUILD_TYPE=Debug
       -DCMAKE_INSTALL_PREFIX=/tmp/metacg/$MCG_BUILD-w_all
-      -DCUBE_LIB=$(dirname $(which cube_info))/../lib
-      -DCUBE_INCLUDE=$(dirname $(which cube_info))/../include/cubelib
+      -DCUBE_DIR=$(dirname $(which cube_info))/..
       -DEXTRAP_INCLUDE=./extern/install/extrap/include
       -DEXTRAP_LIB=./extern/install/extrap/lib
       -DMETACG_BUILD_PGIS=ON

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ $> extinstalldir=./extern/install
 $> cmake -S . -B build \
   -DCMAKE_INSTALL_PREFIX=/where/to/install \
   -DCMAKE_INSTALL_PREFIX="$extinstalldir/metacg" \
-  -DCUBE_LIB="$extinstalldir/cubelib/lib" \
+  -DCUBE_DIR="$extinstalldir/cubelib" \
   -DCUBE_INCLUDE="$extinstalldir/cubelib/include/cubelib" \
   -DEXTRAP_INCLUDE="$extinstalldir/extrap/include" \
   -DEXTRAP_LIB="$extinstalldir/extrap/lib" \
@@ -93,8 +93,7 @@ These options are common for the MetaCG package.
 
 These options are required when building with `METACG_BUILD_PGIS=ON`.
 
-- Path `CUBE_LIB`: Path to the libcube library directory
-- Path `CUBE_INCLUDE`: Path to the libcube include directory
+- Path `CUBE_DIR`: Path to the libcube installation
 - Path `EXTRAP_LIB`: Path to the Extra-P library directory
 - Path `EXTRAP_INCLUDE`: Path to the Extra-P include directory
 

--- a/cmake/CubeLib.cmake
+++ b/cmake/CubeLib.cmake
@@ -1,13 +1,11 @@
 # Cube library installation
-find_library(CUBE_LIB cube4)
-find_path(CUBE_INCLUDE cube)
+find_library(CUBE_LIB cube4 PATHS ${CUBE_DIR}/lib REQUIRED)
+find_path(CUBE_INCLUDE Cube.h PATHS ${CUBE_DIR}/include/cubelib REQUIRED)
+
+message(STATUS "Using cubelib: ${CUBE_LIB}")
+message(STATUS "Using cube headers: ${CUBE_INCLUDE}")
 
 function(add_cube target)
   target_include_directories(${target} SYSTEM PUBLIC ${CUBE_INCLUDE})
-  target_link_directories(
-    ${target}
-    PUBLIC
-    ${CUBE_LIB}
-  )
-  target_link_libraries(${target} PUBLIC cube4)
+  target_link_libraries(${target} PUBLIC ${CUBE_LIB})
 endfunction()

--- a/container/full-build
+++ b/container/full-build
@@ -38,8 +38,7 @@ COPY . /opt/metacg
 
 RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug \
       -DCMAKE_INSTALL_PREFIX=/tmp/metacg \
-      -DCUBE_LIB=$EXTINSTALLDIR/cubelib/lib \
-      -DCUBE_INCLUDE=$EXTINSTALLDIR/cubelib/include/cubelib \
+      -DCUBE_DIR=$EXTINSTALLDIR/cubelib \
       -DEXTRAP_INCLUDE=$EXTINSTALLDIR/extrap/include \
       -DEXTRAP_LIB=$EXTINSTALLDIR/extrap/lib \
       -DMETACG_BUILD_PGIS=ON \

--- a/container/metacg
+++ b/container/metacg
@@ -13,8 +13,7 @@ COPY . /opt/metacg
 
 RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug \
       -DCMAKE_INSTALL_PREFIX=/tmp/metacg \
-      -DCUBE_LIB=$EXTINSTALLDIR/cubelib/lib \
-      -DCUBE_INCLUDE=$EXTINSTALLDIR/cubelib/include/cubelib \
+      -DCUBE_DIR=$EXTINSTALLDIR/cubelib \
       -DEXTRAP_INCLUDE=$EXTINSTALLDIR/extrap/include \
       -DEXTRAP_LIB=$EXTINSTALLDIR/extrap/lib \
       -DMETACG_BUILD_PGIS=ON \


### PR DESCRIPTION
While chasing down a CI failure in our downstream CI, I stumbled on the way how we handle cubelib in CMake. If I'm not mistaken, the current implementation is fishy, because the `find_library` never actually runs (as we always pre-define `CUBE_LIB`). If it did run, the output would be something like `<...>/libcube4.so`, which would then break the `target_link_directories`.

This PR is an attempt to improve this by actually running `find_library` and `find_path` and introducing a new parameter `CUBE_DIR` for the user to specify the cube installation directory. If other's prefer the old way for some reason, I'm happy to close this.