### PR TITLE
[Gitlab CI] Load LLVM for CGValidate test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -221,6 +221,7 @@ test-cgvalidate:
   stage: integration-test
   needs: ["build-mcg"]
   script:
+    - module load clang/$LLVM
     - cd cgcollector/test/integration
     - ./runner.sh $MCG_BUILD
 


### PR DESCRIPTION
This PR includes just one simple change to fix our downstream Gitlab CI by loading the LLVM cluster module when running the CGCollector tests.