### PR TITLE
[GH] Ignore NFC paths to trigger CI

### DIFF
--- a/.github/workflows/mcg-ci.yml
+++ b/.github/workflows/mcg-ci.yml
@@ -2,7 +2,39 @@ name: MetaCG CI
 
 on: 
   push:
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE.txt'
+      - 'CONTRIBUTING.md'
+      - 'CITATION.cff'
+      - 'AUTHORS'
+      - 'formatSrc.sh'
+      - '.gitlab-ci.yml'
+      - '.gitignore'
+      - '.ci-defaults-template.yml'
+      - 'cgcollector/README.md'
+      - 'cgcollector/formatAllSrc.sh'
+      - 'cgcollector/.gitignore'
+      - 'graph/README.md'
+      - 'pgis/README.md'
+      - 'tools/README.md'
   pull_request: 
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE.txt'
+      - 'CONTRIBUTING.md'
+      - 'CITATION.cff'
+      - 'AUTHORS'
+      - 'formatSrc.sh'
+      - '.gitlab-ci.yml'
+      - '.gitignore'
+      - '.ci-defaults-template.yml'
+      - 'cgcollector/README.md'
+      - 'cgcollector/formatAllSrc.sh'
+      - 'cgcollector/.gitignore'
+      - 'graph/README.md'
+      - 'pgis/README.md'
+      - 'tools/README.md'
 
 jobs:
   build:


### PR DESCRIPTION
The GitHub CI can ignore paths that do not add any functionality, e.g. READMEs, when determining whether it should start a CI job.

Unfortunately, it seems that GitHub CI does not yet support YAML anchors. That means we have to duplicate the list of paths-to-ignore.