### PR TITLE
Update nlohmann-json to version 3.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Other version combinations *may* work.
 
 The default is to build only the graph library.
 The build requirements are downloaded at configure time.
-While CMake looks for `nlohmann-json` version 3.10., MetaCG should work starting from version 3.9.2.
+While CMake looks for `nlohmann-json` version 3.12., MetaCG should work starting from version 3.9.2.
 For spdlog, we rely on version 1.8.2 -- other versions *may* work.
 If you do not want to download at configure time, please use the respective CMake options listed below.
 

--- a/cmake/json.cmake
+++ b/cmake/json.cmake
@@ -20,7 +20,7 @@ else()
       CACHE INTERNAL ""
   )
 
-  FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.10.5/json.tar.xz)
+  FetchContent_Declare(json URL https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz)
   FetchContent_MakeAvailable(json)
 endif()
 


### PR DESCRIPTION
MetaCG fails to build with CMake 4.0.0, because the CMake version used by the nlohmann_json version that gets downloaded during configuration is too old: 
```
CMake Error at build/_deps/json-src/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.
```

This PR updates the nlohmann_json version to the newest release (v3.12.0).