### PR TITLE
[NFC] Reformat all scripts via shfmt

### DIFF
--- a/build_submodules.sh
+++ b/build_submodules.sh
@@ -6,13 +6,11 @@
 #"""
 set -euo pipefail
 
-function log()
-{
+function log() {
   echo "[MetaCG] $1"
 }
 
-function err_exit()
-{
+function err_exit() {
   echo "[MetaCG] Error: $1" >&2
   exit 1
 }

--- a/cgcollector/formatAllSrc.sh
+++ b/cgcollector/formatAllSrc.sh
@@ -6,4 +6,3 @@ find ./tools -iname "*.h" -not -type d -exec clang-format -i {} \;
 find ./tools -iname "*.cpp" -not -type d -exec clang-format -i {} \;
 find ./test -iname "*.h" -not -type d -exec clang-format -i {} \;
 find ./test -iname "*.cpp" -not -type d -exec clang-format -i {} \;
-

--- a/cgcollector/test/integration/cgvalidate/base.sh
+++ b/cgcollector/test/integration/cgvalidate/base.sh
@@ -1,10 +1,10 @@
 function report {
-  echo -e "\n[ --------------------------------- ] \n" >> "$logFile"
+  echo -e "\n[ --------------------------------- ] \n" >>"$logFile"
   echo "Running cgvalidate Integration Test $testNo | $failStr"
 }
 
 function failed {
-  fails=$(($fails+1))
+  fails=$(($fails + 1))
   failStr=FAIL
   report
 }
@@ -20,6 +20,5 @@ function checkErrorCode {
   else
     passed
   fi
-  testNo=$(($testNo+1))
+  testNo=$(($testNo + 1))
 }
-

--- a/cgcollector/test/integration/cgvalidate/cgvalidate-run.sh
+++ b/cgcollector/test/integration/cgvalidate/cgvalidate-run.sh
@@ -5,24 +5,23 @@
 build_dir=build # may be changed with opt 'b'
 while getopts ":b:h" opt; do
   case $opt in
-    b)
-      if [ -z $OPTARG ]; then
-        echo "no build directory given, assuming \"build\""
-      fi
-      build_dir=$OPTARG
-      ;;
-    h)
-      echo "use -b to provide a build directory NAME"
-      echo "use -h to print this help"
-      exit 0
-      ;;
-    \?)
-      echo "Invalid option -$OPTARG"
-      exit 1
-      ;;
+  b)
+    if [ -z $OPTARG ]; then
+      echo "no build directory given, assuming \"build\""
+    fi
+    build_dir=$OPTARG
+    ;;
+  h)
+    echo "use -b to provide a build directory NAME"
+    echo "use -h to print this help"
+    exit 0
+    ;;
+  \?)
+    echo "Invalid option -$OPTARG"
+    exit 1
+    ;;
   esac
 done
-
 
 fails=0
 testNo=0
@@ -36,64 +35,62 @@ executable=$buildDir/cgvalidate
 if [ ! -d ${logDir} ]; then
   mkdir ${logDir}
 fi
-echo "" > ${logFile}
+echo "" >${logFile}
 
 # check if cgvalidate is available
-if ! type $executable > /dev/null; then
+if ! type $executable >/dev/null; then
   failed
   exit 1
 else
   passed
-  testNo=$(($testNo+1))
+  testNo=$(($testNo + 1))
 fi
 
 #general
 ## wrong input files
-echo "Invocation: $executable -i $inputDir/general/0001.cubex -c $inputDir/general/0001.cubex" >> $logFile
-$executable -i $inputDir/general/0001.cubex -c $inputDir/general/0001.cubex >> $logFile 2>&1
+echo "Invocation: $executable -i $inputDir/general/0001.cubex -c $inputDir/general/0001.cubex" >>$logFile
+$executable -i $inputDir/general/0001.cubex -c $inputDir/general/0001.cubex >>$logFile 2>&1
 checkErrorCode 2
-echo "Invocation: $executable -i $inputDir/general/0001.ipcg -c $inputDir/general/0001.ipcg" >> $logFile
-$executable -i $inputDir/general/0001.ipcg -c $inputDir/general/0001.ipcg >> $logFile  2>&1
+echo "Invocation: $executable -i $inputDir/general/0001.ipcg -c $inputDir/general/0001.ipcg" >>$logFile
+$executable -i $inputDir/general/0001.ipcg -c $inputDir/general/0001.ipcg >>$logFile 2>&1
 checkErrorCode 3
 
 ## missing edges
-echo "Invocation: $executable -i $inputDir/general/0001_missedcallee.ipcg -c $inputDir/general/0001.cubex" >> $logFile
-$executable -i $inputDir/general/0001_missedcallee.ipcg -c $inputDir/general/0001.cubex >> $logFile  2>&1
+echo "Invocation: $executable -i $inputDir/general/0001_missedcallee.ipcg -c $inputDir/general/0001.cubex" >>$logFile
+$executable -i $inputDir/general/0001_missedcallee.ipcg -c $inputDir/general/0001.cubex >>$logFile 2>&1
 checkErrorCode 1
-echo "Invocation: $executable -i $inputDir/general/0001_missedparent.ipcg -c $inputDir/general/0001.cubex" >> $logFile
-$executable -i $inputDir/general/0001_missedparent.ipcg -c $inputDir/general/0001.cubex >> $logFile  2>&1
+echo "Invocation: $executable -i $inputDir/general/0001_missedparent.ipcg -c $inputDir/general/0001.cubex" >>$logFile
+$executable -i $inputDir/general/0001_missedparent.ipcg -c $inputDir/general/0001.cubex >>$logFile 2>&1
 checkErrorCode 1
-echo "Invocation: $executable -i $inputDir/general/0001_missedboth.ipcg -c $inputDir/general/0001.cubex" >> $logFile
-$executable -i $inputDir/general/0001_missedboth.ipcg -c $inputDir/general/0001.cubex >> $logFile  2>&1
+echo "Invocation: $executable -i $inputDir/general/0001_missedboth.ipcg -c $inputDir/general/0001.cubex" >>$logFile
+$executable -i $inputDir/general/0001_missedboth.ipcg -c $inputDir/general/0001.cubex >>$logFile 2>&1
 checkErrorCode 1
 
 ## successfull run
-echo "Invocation $executable -i $inputDir/general/0001.ipcg -c $inputDir/general/0001.cubex" >> $logFile
-$executable -i $inputDir/general/0001.ipcg -c $inputDir/general/0001.cubex >> $logFile 2>&1
+echo "Invocation $executable -i $inputDir/general/0001.ipcg -c $inputDir/general/0001.cubex" >>$logFile
+$executable -i $inputDir/general/0001.ipcg -c $inputDir/general/0001.cubex >>$logFile 2>&1
 checkErrorCode 0
 
 #virtual
-echo "Invocation: $executable -i $inputDir/virtual/exp1.ipcg -c $inputDir/virtual/exp1.cubex" >> $logFile
-$executable -i $inputDir/virtual/exp1.ipcg -c $inputDir/virtual/exp1.cubex >> $logFile  2>&1
+echo "Invocation: $executable -i $inputDir/virtual/exp1.ipcg -c $inputDir/virtual/exp1.cubex" >>$logFile
+$executable -i $inputDir/virtual/exp1.ipcg -c $inputDir/virtual/exp1.cubex >>$logFile 2>&1
 checkErrorCode 0
-echo "Invocation: $executable -i $inputDir/virtual/exp2.ipcg -c $inputDir/virtual/exp2.cubex" >> $logFile
-$executable -i $inputDir/virtual/exp2.ipcg -c $inputDir/virtual/exp2.cubex >> $logFile  2>&1
+echo "Invocation: $executable -i $inputDir/virtual/exp2.ipcg -c $inputDir/virtual/exp2.cubex" >>$logFile
+$executable -i $inputDir/virtual/exp2.ipcg -c $inputDir/virtual/exp2.cubex >>$logFile 2>&1
 checkErrorCode 0
-echo "Invocation: $executable -i $inputDir/virtual/exp3.ipcg -c $inputDir/virtual/exp3.cubex" >> $logFile
-$executable -i $inputDir/virtual/exp3.ipcg -c $inputDir/virtual/exp3.cubex >> $logFile  2>&1
+echo "Invocation: $executable -i $inputDir/virtual/exp3.ipcg -c $inputDir/virtual/exp3.cubex" >>$logFile
+$executable -i $inputDir/virtual/exp3.ipcg -c $inputDir/virtual/exp3.cubex >>$logFile 2>&1
 checkErrorCode 0
 
 #fix
-echo "Invocation: $executable -i $inputDir/fix/miss.ipcg -c $inputDir/fix/0001.cubex -p" >> $logFile
-$executable -i $inputDir/fix/miss.ipcg -c $inputDir/fix/0001.cubex -p -o $inputDir/fix/miss.ipcg.patched-${CI_CONCURRENT_ID} >> $logFile 2>&1
-$executable -i $inputDir/fix/miss.ipcg.patched-${CI_CONCURRENT_ID} -c $inputDir/fix/0001.cubex >> $logFile 2>&1
+echo "Invocation: $executable -i $inputDir/fix/miss.ipcg -c $inputDir/fix/0001.cubex -p" >>$logFile
+$executable -i $inputDir/fix/miss.ipcg -c $inputDir/fix/0001.cubex -p -o $inputDir/fix/miss.ipcg.patched-${CI_CONCURRENT_ID} >>$logFile 2>&1
+$executable -i $inputDir/fix/miss.ipcg.patched-${CI_CONCURRENT_ID} -c $inputDir/fix/0001.cubex >>$logFile 2>&1
 checkErrorCode 0
-echo "Invocation: $executable -i $inputDir/fixvirtual/miss.ipcg -c $inputDir/fixvirtual/exp1.cubex -p" >> $logFile
-$executable -i $inputDir/fixvirtual/miss.ipcg -c $inputDir/fixvirtual/exp1.cubex -p -o $inputDir/fixvirtual/miss.ipcg.patched-${CI_CONCURRENT_ID}>> $logFile 2>&1
-$executable -i $inputDir/fixvirtual/miss.ipcg.patched-${CI_CONCURRENT_ID} -c $inputDir/fixvirtual/exp1.cubex >> $logFile 2>&1
+echo "Invocation: $executable -i $inputDir/fixvirtual/miss.ipcg -c $inputDir/fixvirtual/exp1.cubex -p" >>$logFile
+$executable -i $inputDir/fixvirtual/miss.ipcg -c $inputDir/fixvirtual/exp1.cubex -p -o $inputDir/fixvirtual/miss.ipcg.patched-${CI_CONCURRENT_ID} >>$logFile 2>&1
+$executable -i $inputDir/fixvirtual/miss.ipcg.patched-${CI_CONCURRENT_ID} -c $inputDir/fixvirtual/exp1.cubex >>$logFile 2>&1
 checkErrorCode 0
-
 
 # finalize
 exit $fails
-

--- a/cgcollector/test/integration/runner.sh
+++ b/cgcollector/test/integration/runner.sh
@@ -5,8 +5,7 @@ fails=0
 cd cgvalidate
 bash cgvalidate-run.sh -b "$1"
 
-fails=$(($fails+$?))
+fails=$(($fails + $?))
 
 echo Failed tests: $fails
 exit $fails
-

--- a/cgcollector/test/run_aa_test.sh
+++ b/cgcollector/test/run_aa_test.sh
@@ -42,7 +42,6 @@ multiTests=(0042 0043 0044 0050 0053 0060)
 # Multi-file aa tests
 multiTestsAA=(0070 0071 0072 0214 0240 0241)
 
-
 fails=0
 
 # Single File

--- a/cgcollector/test/testBase.sh
+++ b/cgcollector/test/testBase.sh
@@ -1,4 +1,3 @@
-
 cgcollectorExe=cgcollector
 testerExe=cgsimpletester
 cgmergeExe=cgmerge
@@ -26,7 +25,7 @@ function applyFileFormatOneToSingleTU {
 
   echo "Running ${testerExe} on ${tfile}"
   $cgcollectorExe --metacg-format-version=1 ${addFlags} --output ${gfile} $tfile -- >>log/testrun.log 2>&1
-  cat $gfile | python3 -m json.tool > ${gfile}_
+  cat $gfile | python3 -m json.tool >${gfile}_
   mv ${gfile}_ ${gfile}
   $testerExe $tgt $gfile >>log/testrun.log 2>&1
 
@@ -55,9 +54,9 @@ function applyFileFormatTwoToSingleTU {
   gfile=${testCaseFile/cpp/ipcg}-${CI_CONCURRENT_ID}
   tgt=${testCaseFile/cpp/gtmcg}
 
- echo "Running tester on ${tfile}"
+  echo "Running tester on ${tfile}"
   $cgcollectorExe --metacg-format-version=2 ${addFlags} --output ${gfile} $tfile -- >>log/testrun.log 2>&1
-  cat $gfile | python3 -m json.tool > ${gfile}_
+  cat $gfile | python3 -m json.tool >${gfile}_
   mv ${gfile}_ ${gfile}
   $testerExe $tgt $gfile >>log/testrun.log 2>&1
 
@@ -83,9 +82,9 @@ function applyFileFormatTwoToSingleTUWithAA {
   gfile=${testCaseFile/cpp/ipcg}-${CI_CONCURRENT_ID}
   tgt=${testCaseFile/cpp/gtaacg}
 
- echo "Running tester on ${tfile}"
+  echo "Running tester on ${tfile}"
   $cgcollectorExe --metacg-format-version=2 --capture-ctors-dtors --capture-stack-ctors-dtors --enable-AA ${addFlags} --output ${gfile} $tfile -- >>log/testrun.log 2>&1
-  cat $gfile | python3 -m json.tool > ${gfile}_
+  cat $gfile | python3 -m json.tool >${gfile}_
   mv ${gfile}_ ${gfile}
   $testerExe $tgt $gfile >>log/testrun.log 2>&1
 
@@ -220,7 +219,7 @@ function applyFileFormatTwoToMultiTUWithAA {
 
   # Translation-unit-local
   $cgcollectorExe --metacg-format-version=2 --capture-ctors-dtors --capture-stack-ctors-dtors --enable-AA --output ./input/multiTU/${ipcgTaFile} ./input/multiTU/$taFile -- >>log/testrun.log 2>&1
-  $cgcollectorExe --metacg-format-version=2 --capture-ctors-dtors --capture-stack-ctors-dtors --enable-AA --output ./input/multiTU/${ipcgTbFile}  ./input/multiTU/$tbFile -- >>log/testrun.log 2>&1
+  $cgcollectorExe --metacg-format-version=2 --capture-ctors-dtors --capture-stack-ctors-dtors --enable-AA --output ./input/multiTU/${ipcgTbFile} ./input/multiTU/$tbFile -- >>log/testrun.log 2>&1
 
   cat ./input/multiTU/${ipcgTaFile} | python3 -m json.tool >./input/multiTU/${ipcgTaFile}_
   mv ./input/multiTU/${ipcgTaFile}_ ./input/multiTU/${ipcgTaFile}
@@ -255,23 +254,22 @@ function applyFileFormatTwoToMultiTUWithAA {
   return $fail
 }
 
-
 while getopts ":b:h" opt; do
   case $opt in
-    b)
-      if [ -z $OPTARG ]; then
-        echo "no build directory given, assuming \"build\""
-      fi
-      build_dir=$OPTARG
-      ;;
-    h)
-      echo "use -b to provide a build directory NAME"
-      echo "use -h to print this help"
-      exit 0
-      ;;
-    \?)
-      echo "Invalid option -$OPTARG"
-      exit 1
-      ;;
+  b)
+    if [ -z $OPTARG ]; then
+      echo "no build directory given, assuming \"build\""
+    fi
+    build_dir=$OPTARG
+    ;;
+  h)
+    echo "use -b to provide a build directory NAME"
+    echo "use -h to print this help"
+    exit 0
+    ;;
+  \?)
+    echo "Invalid option -$OPTARG"
+    exit 1
+    ;;
   esac
 done

--- a/formatSrc.sh
+++ b/formatSrc.sh
@@ -4,4 +4,3 @@ git-clang-format devel
 # Apply CMake formatting
 find . -name "CMakeLists.txt" -exec cmake-format -i {} \;
 find ./cmake -name "*.cmake" -type f -exec cmake-format -i {} \;
-

--- a/graph/test/integration/CallgraphMerge/MergeTestRunner.sh
+++ b/graph/test/integration/CallgraphMerge/MergeTestRunner.sh
@@ -12,7 +12,7 @@ function merge {
   fail=0
   tc=$1
   suffix="$2"
-  
+
   ipcgTaFile="${tc}_a${suffix}.ipcg"
   ipcgTbFile="${tc}_b${suffix}.ipcg"
   gtCombFile="${tc}_both${suffix}.gtmcg"
@@ -36,25 +36,25 @@ function merge {
 
 while getopts ":b:h:g" opt; do
   case $opt in
-    b)
-      if [ -z $OPTARG ]; then
-        echo "no build directory given, assuming \"build\""
-      fi
-      build_dir=$OPTARG
-      ;;
-    h)
-      echo "use -b to provide a build directory NAME"
-      echo "use -h to print this help"
-      exit 0
-      ;;
-    g)
-      echo "Regenerating ground truth files"
-      generate_gt=1
-      ;;
-    \?)
-      echo "Invalid option -$OPTARG"
-      exit 1
-      ;;
+  b)
+    if [ -z $OPTARG ]; then
+      echo "no build directory given, assuming \"build\""
+    fi
+    build_dir=$OPTARG
+    ;;
+  h)
+    echo "use -b to provide a build directory NAME"
+    echo "use -h to print this help"
+    exit 0
+    ;;
+  g)
+    echo "Regenerating ground truth files"
+    generate_gt=1
+    ;;
+  \?)
+    echo "Invalid option -$OPTARG"
+    exit 1
+    ;;
   esac
 done
 
@@ -81,6 +81,5 @@ for tc in "${tests[@]}"; do
   fails=$((fails + fail))
 done
 echo "Test failures: $fails"
-
 
 exit $fails

--- a/graph/test/integration/TargetCollector/TestRunner.sh
+++ b/graph/test/integration/TargetCollector/TestRunner.sh
@@ -6,62 +6,62 @@ timeStamp=$(date +%s)
 build_dir=build # may be changed with opt 'b'
 while getopts ":b:h" opt; do
   case $opt in
-    b)
-      if [ -z $OPTARG ]; then
-        echo "no build directory given, assuming \"build\""
-      fi
-      build_dir=$OPTARG
-      ;;
-    h)
-      echo "use -b to provide a build directory NAME"
-      echo "use -h to print this help"
-      exit 0
-      ;;
-    \?)
-      echo "Invalid option -$OPTARG"
-      exit 1
-      ;;
+  b)
+    if [ -z $OPTARG ]; then
+      echo "no build directory given, assuming \"build\""
+    fi
+    build_dir=$OPTARG
+    ;;
+  h)
+    echo "use -b to provide a build directory NAME"
+    echo "use -h to print this help"
+    exit 0
+    ;;
+  \?)
+    echo "Invalid option -$OPTARG"
+    exit 1
+    ;;
   esac
 done
 
 echo "Running integration test for TargetCollector script"
 
-echo "{}" > src/wholeProgramCG-${CI_CONCURRENT_ID}.ipcg
-test_command=(python3 ../../../../TargetCollector.py \
-     -a=".." \
-     -g=both \
-     -b=build-${CI_CONCURRENT_ID} \
-     -c="$PWD"/../../../../"${build_dir}"/cgcollector/tools/cgcollector \
-     -m="$PWD"/../../../../"${build_dir}"/cgcollector/tools/cgmerge \
-     -o="src/wholeProgramCG-${CI_CONCURRENT_ID}.ipcg" \
-     -t testExe \
-     --ci-concurrent-suffix=$CI_CONCURRENT_ID
-   )
+echo "{}" >src/wholeProgramCG-${CI_CONCURRENT_ID}.ipcg
+test_command=(python3 ../../../../TargetCollector.py
+  -a=".."
+  -g=both
+  -b=build-${CI_CONCURRENT_ID}
+  -c="$PWD"/../../../../"${build_dir}"/cgcollector/tools/cgcollector
+  -m="$PWD"/../../../../"${build_dir}"/cgcollector/tools/cgmerge
+  -o="src/wholeProgramCG-${CI_CONCURRENT_ID}.ipcg"
+  -t testExe
+  --ci-concurrent-suffix=$CI_CONCURRENT_ID
+)
 
 echo "${test_command[@]}"
 "${test_command[@]}"
 
 echo "--- Now running diffs ---"
 
-diff -q ./src/foo.cpp${CI_CONCURRENT_ID}.ipcg ./src/foo.expected > /dev/null 2>&1
+diff -q ./src/foo.cpp${CI_CONCURRENT_ID}.ipcg ./src/foo.expected >/dev/null 2>&1
 resultOfTest=$?
 if [ $resultOfTest -ne 0 ]; then
   echo "diff for foo failed"
-	exit 1
+  exit 1
 fi
 
-diff -q ./src/main.cpp${CI_CONCURRENT_ID}.ipcg ./src/main.expected > /dev/null 2>&1
+diff -q ./src/main.cpp${CI_CONCURRENT_ID}.ipcg ./src/main.expected >/dev/null 2>&1
 resultOfTest=$?
 if [ $resultOfTest -ne 0 ]; then
   echo "diff for main failed"
-	exit 1
+  exit 1
 fi
 
-diff -q ./src/wholeProgramCG-${CI_CONCURRENT_ID}.ipcg ./src/wholeProgramCG.expected > /dev/null 2>&1
+diff -q ./src/wholeProgramCG-${CI_CONCURRENT_ID}.ipcg ./src/wholeProgramCG.expected >/dev/null 2>&1
 resultOfTest=$?
 if [ $resultOfTest -ne 0 ]; then
   echo "diff for wholeProgram failed"
-	exit 1
+  exit 1
 fi
 
 rm ./src/foo.cpp${CI_CONCURRENT_ID}.ipcg

--- a/pgis/test/integration/base.sh
+++ b/pgis/test/integration/base.sh
@@ -1,66 +1,63 @@
-
 function check_selection {
   testSuite=$1
-	testNo=$(echo $2 | cut -d'.' -f 1)
-	outDir=$3
+  testNo=$(echo $2 | cut -d'.' -f 1)
+  outDir=$3
   ciConcurrentId=$4
-	aflFileExt=""
+  aflFileExt=""
 
-	cat ${outDir}/instrumented-${testNo}.txt 2>&1 > /dev/null
-	if [ $? -ne 0 ]; then
-		echo "No result file"
-		return 255
-	fi
+  cat ${outDir}/instrumented-${testNo}.txt 2>&1 >/dev/null
+  if [ $? -ne 0 ]; then
+    echo "No result file"
+    return 255
+  fi
 
-	cat ${PWD}/${testNo}.afl > /dev/null 2>&1 
-	if [ $? -eq 0 ]; then
-		aflFileExt="afl"
-	else
-	  cat ${PWD}/${testNo}.spl > /dev/null 2>&1 
-		if [ $? -eq 0 ]; then
-			aflFileExt="spl"
-		fi
-	fi
-	if [ -z "$aflFileExt" ]; then
-		echo "No awaited-function-list file"
-		return 255
-	fi
+  cat ${PWD}/${testNo}.afl >/dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    aflFileExt="afl"
+  else
+    cat ${PWD}/${testNo}.spl >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
+      aflFileExt="spl"
+    fi
+  fi
+  if [ -z "$aflFileExt" ]; then
+    echo "No awaited-function-list file"
+    return 255
+  fi
 
   sortedTmpICFile="/tmp/pgis_temp_${testSuite}_res-$ciConcurrentId.txt"
   sortedTmpBLFile="/tmp/pgis_temp_${testSuite}_bl-$ciConcurrentId.txt"
 
-	cat ${outDir}/instrumented-${testNo}.txt | sort | uniq > $sortedTmpICFile
-	cat ${PWD}/${testNo}.${aflFileExt} | sort | uniq > $sortedTmpBLFile
-	diff -q $sortedTmpICFile $sortedTmpBLFile 2>&1 > /dev/null
+  cat ${outDir}/instrumented-${testNo}.txt | sort | uniq >$sortedTmpICFile
+  cat ${PWD}/${testNo}.${aflFileExt} | sort | uniq >$sortedTmpBLFile
+  diff -q $sortedTmpICFile $sortedTmpBLFile 2>&1 >/dev/null
   resultOfTest=$?
-	if [ $resultOfTest -eq 0 ]; then
-	  rm ${outDir}/instrumented-${testNo}.txt
-	fi
+  if [ $resultOfTest -eq 0 ]; then
+    rm ${outDir}/instrumented-${testNo}.txt
+  fi
   rm $sortedTmpBLFile $sortedTmpICFile
-	return $resultOfTest
+  return $resultOfTest
 }
 
-
 function error_exit {
-	echo "An error occured with argument $1"
-	exit -1
+  echo "An error occured with argument $1"
+  exit -1
 }
 
 function check_and_print {
-	fails=$1
-	testFile=$2
-	errCode=$3
-	thisFail=0
-	failStr=' PASS'
+  fails=$1
+  testFile=$2
+  errCode=$3
+  thisFail=0
+  failStr=' PASS'
 
   if [ ${errCode} -ne 0 ]; then
     echo "Error: ${errCode}"
-		fails=$((fails+1))
-		failStr=' FAIL'
-	fi
+    fails=$((fails + 1))
+    failStr=' FAIL'
+  fi
 
-	echo "Test ${testFile} | ${failStr}"
+  echo "Test ${testFile} | ${failStr}"
 
-	return ${fails}
+  return ${fails}
 }
-

--- a/pgis/test/integration/basicTestRunner.sh
+++ b/pgis/test/integration/basicTestRunner.sh
@@ -9,21 +9,21 @@ timeStamp=$(date +%s)
 
 while getopts ":b:h" opt; do
   case $opt in
-    b)
-      if [ -z $OPTARG ]; then
-        echo "no build directory given, assuming \"build\""
-      fi
-      buildDirParam=$OPTARG
-      ;;
-    h)
-      echo "use -b to provide a build directory NAME"
-      echo "use -h to print this help"
-      exit 0
-      ;;
-    \?)
-      echo "Invalid option -$OPTARG"
-      exit 1
-      ;;
+  b)
+    if [ -z $OPTARG ]; then
+      echo "no build directory given, assuming \"build\""
+    fi
+    buildDirParam=$OPTARG
+    ;;
+  h)
+    echo "use -b to provide a build directory NAME"
+    echo "use -h to print this help"
+    exit 0
+    ;;
+  \?)
+    echo "Invalid option -$OPTARG"
+    exit 1
+    ;;
   esac
 done
 
@@ -43,12 +43,12 @@ fi
 echo "Running Tests with build directory: ${buildDir}"
 
 for testFile in ./ipcgread/*.ipcg; do
-	$testExec --out-dir $outDir --static $testFile >${logFile} 2>&1
-	errCode=$?
-	check_and_print $fails $testFile $errCode
-	fails=$?
+  $testExec --out-dir $outDir --static $testFile >${logFile} 2>&1
+  errCode=$?
+  check_and_print $fails $testFile $errCode
+  fails=$?
 
-	echo "Running PGIS base test $testNo"
+  echo "Running PGIS base test $testNo"
 done
 
 echo "Failed tests: ${fails}"

--- a/pgis/test/integration/inputdynamic/dynamic_run.sh
+++ b/pgis/test/integration/inputdynamic/dynamic_run.sh
@@ -1,4 +1,3 @@
-
 buildDir=$1
 outDir=$2
 testNo=$3
@@ -9,4 +8,3 @@ cubeTest="${testNo/ipcg/cubex}"
 cmd="${binary} --use-cs-instrumentation --out-dir $outDir ${PWD}/$testNo --cube ${PWD}/$cubeTest"
 echo $cmd
 $cmd
-

--- a/pgis/test/integration/inputdynamic/dynamic_run_v2.sh
+++ b/pgis/test/integration/inputdynamic/dynamic_run_v2.sh
@@ -1,4 +1,3 @@
-
 buildDir=$1
 outDir=$2
 testNo=$3
@@ -10,4 +9,3 @@ cubeTest="${testNo/mcg/cubex}"
 cmd="${binary} --use-cs-instrumentation --metacg-format 2 --out-dir $outDir ${PWD}/$testNo --cube ${PWD}/$cubeTest"
 echo $cmd
 $cmd
-

--- a/pgis/test/integration/inputimbalance/imbalance_run.sh
+++ b/pgis/test/integration/inputimbalance/imbalance_run.sh
@@ -1,4 +1,3 @@
-
 buildDir=$1
 outDir=$2
 testNo=$3
@@ -9,4 +8,3 @@ cubeTest="${testNo/ipcg/cubex}"
 cmd="${binary} --out-dir $outDir --cube ${PWD}/$cubeTest --parameter-file ${PWD}/parameters.json --lide 1 --debug 1 ${PWD}/$testNo"
 echo $cmd
 $cmd
-

--- a/pgis/test/integration/inputimbalance/imbalance_run_v2.sh
+++ b/pgis/test/integration/inputimbalance/imbalance_run_v2.sh
@@ -1,4 +1,3 @@
-
 buildDir=$1
 outDir=$2
 testNo=$3
@@ -10,4 +9,3 @@ cubeTest="${testNo/mcg/cubex}"
 cmd="${binary} --metacg-format 2 --out-dir $outDir --cube ${PWD}/$cubeTest --parameter-file ${PWD}/parameters.json --lide 1 --debug 1 ${PWD}/$testNo"
 echo $cmd
 $cmd
-

--- a/pgis/test/integration/inputmodeling/generate_cubes.sh
+++ b/pgis/test/integration/inputmodeling/generate_cubes.sh
@@ -7,9 +7,9 @@ seqStartArg=$3
 seqIncArg=$4
 seqStopArg=$5
 
-if [[ -z "${sourceFileArg}" ]] ; then
-	echo "need to provide source file"
-	exit 1
+if [[ -z "${sourceFileArg}" ]]; then
+  echo "need to provide source file"
+  exit 1
 fi
 
 paramName="${paramNameArg:-X}"
@@ -17,15 +17,15 @@ seqStart="${seqStartArg:-2}"
 seqInc="${seqIncArg:-2}"
 seqStop="${seqStopArg:-10}"
 
-for s in $(seq ${seqStart} ${seqInc} ${seqStop}) ; do 
-	echo ${s}; 
-	scorep gcc -D${paramName}=${s} ${sourceFileArg} ;
-	#scorep gcc -D${paramName}=${s} ${sourceFileArg} -o a.${paramName}${s}.out ; 
-  for i in $(seq 1 5) ; do
-	  ./a.out ; 
-	  mkdir t.${paramName}${s}.postfix.r${i} ; 
-	  mv scorep-*/profile.cubex ./t.${paramName}${s}.postfix.r${i}/profile.cubex ; 
-	  rm -r scorep-* ;
+for s in $(seq ${seqStart} ${seqInc} ${seqStop}); do
+  echo ${s}
+  scorep gcc -D${paramName}=${s} ${sourceFileArg}
+  #scorep gcc -D${paramName}=${s} ${sourceFileArg} -o a.${paramName}${s}.out ;
+  for i in $(seq 1 5); do
+    ./a.out
+    mkdir t.${paramName}${s}.postfix.r${i}
+    mv scorep-*/profile.cubex ./t.${paramName}${s}.postfix.r${i}/profile.cubex
+    rm -r scorep-*
   done
-	mv ./a.out ./a.${paramName}${s}.out ; 
+  mv ./a.out ./a.${paramName}${s}.out
 done

--- a/pgis/test/integration/inputmodeling/modeling_run.sh
+++ b/pgis/test/integration/inputmodeling/modeling_run.sh
@@ -1,4 +1,3 @@
-
 buildDir=$1
 outDir=$2
 testNo=$3
@@ -10,7 +9,6 @@ cmd="${binary} --use-cs-instrumentation --debug 2 --out-dir $outDir --parameter-
 echo $cmd
 $cmd
 
-
 echo -e "\n [ ------------- EXPORT FEATURE ----------------- ]\n"
 
 outfile=${testNo/ipcg/2-${CI_CONCURRENT_ID}.ipcg}
@@ -20,4 +18,3 @@ echo $cmd
 $cmd
 
 #rm ${PWD}/${outfile}
-

--- a/pgis/test/integration/inputmodeling/modeling_run_v2.sh
+++ b/pgis/test/integration/inputmodeling/modeling_run_v2.sh
@@ -1,4 +1,3 @@
-
 buildDir=$1
 outDir=$2
 testNo=$3
@@ -16,4 +15,3 @@ $cmd
 #cp ${testNo} ${outfile}
 #${binary} --debug 2 --export --out-file $outDir --extrap ${PWD}/${extrapDef} ${PWD}/$outfile
 #rm ${PWD}/${outfile}
-

--- a/pgis/test/integration/inputstatic/static_run.sh
+++ b/pgis/test/integration/inputstatic/static_run.sh
@@ -1,10 +1,9 @@
-
 buildDir=$1
 outDir=$2
 testNo=$3
 binary=${buildDir}/tool/pgis_pira
 if [ -z $4 ]; then
-	scorepOut=""
+  scorepOut=""
 else
   scorepOut="--scorep-out"
 fi
@@ -13,4 +12,3 @@ echo -e "Static Selection\nRunning $binary"
 cmd="${binary} ${scorepOut} --out-dir $outDir --use-cs-instrumentation --static ${PWD}/$testNo"
 echo $cmd
 $cmd
-

--- a/pgis/test/integration/inputstatic/static_run_v2.sh
+++ b/pgis/test/integration/inputstatic/static_run_v2.sh
@@ -1,10 +1,9 @@
-
 buildDir=$1
 outDir=$2
 testNo=$3
 binary=${buildDir}/tool/pgis_pira
 if [ -z $4 ]; then
-	scorepOut=""
+  scorepOut=""
 else
   scorepOut="--scorep-out"
 fi
@@ -13,5 +12,3 @@ echo -e "Static Selection\nRunning $binary"
 cmd="${binary} ${scorepOut} --metacg-format 2 --out-dir $outDir --use-cs-instrumentation --static ${PWD}/$testNo"
 echo $cmd
 $cmd
-
-

--- a/pgis/test/integration/selectionTestRunner.sh
+++ b/pgis/test/integration/selectionTestRunner.sh
@@ -8,29 +8,29 @@ timeStamp=$(date +%s)
 
 while getopts ":t:b:h" opt; do
   case $opt in
-    b)
-      echo "$OPTARG"
-      if [ -z $OPTARG ]; then
-        echo "no build directory given, assuming \"build\""
-      else
-        echo "Using ${OPTARG} as build dir"
-        buildDirParam="${OPTARG}"
-      fi
-      ;;
-    t)
-      echo "Running testsuite ${OPTARG}"
-      testSuite=${OPTARG}
-      ;;
-    h)
-      echo "use -b to provide a build directory NAME"
-      echo "use -t to provide a test suite name <static|dynamic|modeling|imbalance>"
-      echo "use -h to print this help"
-      exit 0
-      ;;
-    \?)
-      echo "Invalid option -$opt"
-      exit 1
-      ;;
+  b)
+    echo "$OPTARG"
+    if [ -z $OPTARG ]; then
+      echo "no build directory given, assuming \"build\""
+    else
+      echo "Using ${OPTARG} as build dir"
+      buildDirParam="${OPTARG}"
+    fi
+    ;;
+  t)
+    echo "Running testsuite ${OPTARG}"
+    testSuite=${OPTARG}
+    ;;
+  h)
+    echo "use -b to provide a build directory NAME"
+    echo "use -t to provide a test suite name <static|dynamic|modeling|imbalance>"
+    echo "use -h to print this help"
+    exit 0
+    ;;
+  \?)
+    echo "Invalid option -$opt"
+    exit 1
+    ;;
   esac
 done
 
@@ -47,126 +47,123 @@ logFile=${logDir}/${testSuite}-${CI_CONCURRENT_ID}.log
 
 echo "Running Tests with build directory: ${buildDir}"
 
-
 rm -rf $outDir && mkdir $outDir
 rm -rf $logDir && mkdir ${logDir}
 
 cd input$testSuite || error_exit "cd input$testSuite"
 
-
 echo "Running $testSuite tests with build directory: $buildDir"
 fails=0
 
 for testNoInit in *.afl; do
-	echo -e "\n== AFL-based MetaCG v1.0 tests =="
-	if [ "$testNoInit" == "*.afl" ]; then
-		echo "No tests to run"
-#		exit $fails
-	fi
-	testNo="${testNoInit/afl/ipcg}"
-	echo "Running $testNo"
-	thisFail=0
+  echo -e "\n== AFL-based MetaCG v1.0 tests =="
+  if [ "$testNoInit" == "*.afl" ]; then
+    echo "No tests to run"
+    #		exit $fails
+  fi
+  testNo="${testNoInit/afl/ipcg}"
+  echo "Running $testNo"
+  thisFail=0
 
   # We now overwrite logs with each execution. On error, the log is echo'ed inside
   # this script.
-	bash "${testSuite}_run.sh" $buildDir $outDir $testNo 2>&1 > "$logFile"
-	#bash "${testSuite}_run.sh" $buildDir $outDir $testNo
+  bash "${testSuite}_run.sh" $buildDir $outDir $testNo 2>&1 >"$logFile"
+  #bash "${testSuite}_run.sh" $buildDir $outDir $testNo
 
-	if [ $? -ne 0 ]; then
-		fails=$(($fails+1))
-		thisFail=1
-	fi
-	
-	check_selection $testSuite $testNo $outDir $CI_CONCURRENT_ID
+  if [ $? -ne 0 ]; then
+    fails=$(($fails + 1))
+    thisFail=1
+  fi
 
-	if [ $? -ne 0 ]; then
-		fails=$(($fails+1))
-		thisFail=1
-	fi
-	if [ $thisFail -eq 1 ]; then
-		failStr=' FAIL'
+  check_selection $testSuite $testNo $outDir $CI_CONCURRENT_ID
+
+  if [ $? -ne 0 ]; then
+    fails=$(($fails + 1))
+    thisFail=1
+  fi
+  if [ $thisFail -eq 1 ]; then
+    failStr=' FAIL'
     # In case of error, print the log file
     echo ">>> ERROR OCCURRED -- Dumping log <<<"
     cat $logFile
-	else
-		failStr=' PASS'
-	fi
-	echo -e "\n[ --------------------------------- ] \n" >> "$logFile"
-	echo "Running PGIS Integration Test $testNo : $testFile | $failStr"
+  else
+    failStr=' PASS'
+  fi
+  echo -e "\n[ --------------------------------- ] \n" >>"$logFile"
+  echo "Running PGIS Integration Test $testNo : $testFile | $failStr"
 done
 
 for testNoInit in *.afl; do
-	echo -e "\n== AFL-based MetaCG v2.0 tests =="
-	if [ "$testNoInit" == "*.afl" ]; then
-		echo "No tests to run"
-#		exit $fails
-	fi
-	testNo="${testNoInit/afl/mcg}"
-	echo "Running $testNo"
-	thisFail=0
+  echo -e "\n== AFL-based MetaCG v2.0 tests =="
+  if [ "$testNoInit" == "*.afl" ]; then
+    echo "No tests to run"
+    #		exit $fails
+  fi
+  testNo="${testNoInit/afl/mcg}"
+  echo "Running $testNo"
+  thisFail=0
 
-	bash "${testSuite}_run_v2.sh" $buildDir $outDir $testNo > "$logFile" 2>&1
-	#bash "${testSuite}_run_v2.sh" $buildDir $outDir $testNo
+  bash "${testSuite}_run_v2.sh" $buildDir $outDir $testNo >"$logFile" 2>&1
+  #bash "${testSuite}_run_v2.sh" $buildDir $outDir $testNo
 
-	if [ $? -ne 0 ]; then
-		fails=$(($fails+1))
-		thisFail=1
-	fi
-	
-	check_selection $testSuite $testNo $outDir $CI_CONCURRENT_ID
+  if [ $? -ne 0 ]; then
+    fails=$(($fails + 1))
+    thisFail=1
+  fi
 
-	if [ $? -ne 0 ]; then
-		fails=$(($fails+1))
-		thisFail=1
-	fi
-	if [ $thisFail -eq 1 ]; then
-		failStr=' FAIL'
+  check_selection $testSuite $testNo $outDir $CI_CONCURRENT_ID
+
+  if [ $? -ne 0 ]; then
+    fails=$(($fails + 1))
+    thisFail=1
+  fi
+  if [ $thisFail -eq 1 ]; then
+    failStr=' FAIL'
     # in case of error, print the log file
     echo ">>> ERROR OCCURRED -- Dumping log <<<"
     cat $logFile
-	else
-		failStr=' PASS'
-	fi
-	echo -e "\n[ --------------------------------- ] \n" >> "$logFile"
-	echo "Running PGIS Integration Test $testNo : $testFile | $failStr"
+  else
+    failStr=' PASS'
+  fi
+  echo -e "\n[ --------------------------------- ] \n" >>"$logFile"
+  echo "Running PGIS Integration Test $testNo : $testFile | $failStr"
 done
 
 for testNoInit in *.spl; do
-	echo -e "\n== SPL-based tests =="
-	if [ "$testNoInit" == "*.spl" ]; then
-		echo "No test to run"
-		echo "So far failed tests $fails"
-		exit $fails
-	fi
-	testNo="${testNoInit/spl/ipcg}"
-	echo "Running $testNo"
-	thisFail=0
+  echo -e "\n== SPL-based tests =="
+  if [ "$testNoInit" == "*.spl" ]; then
+    echo "No test to run"
+    echo "So far failed tests $fails"
+    exit $fails
+  fi
+  testNo="${testNoInit/spl/ipcg}"
+  echo "Running $testNo"
+  thisFail=0
 
-	bash "${testSuite}_run.sh" $buildDir $outDir $testNo "spl" 2>&1 > "$logFile"
-	#bash "${testSuite}_run.sh" $buildDir $outDir $testNo
+  bash "${testSuite}_run.sh" $buildDir $outDir $testNo "spl" 2>&1 >"$logFile"
+  #bash "${testSuite}_run.sh" $buildDir $outDir $testNo
 
-	if [ $? -ne 0 ]; then
-		fails=$(($fails+1))
-		thisFail=1
-	fi
-	
-	check_selection $testSuite $testNo $outDir $CI_CONCURRENT_ID
+  if [ $? -ne 0 ]; then
+    fails=$(($fails + 1))
+    thisFail=1
+  fi
 
-	if [ $? -ne 0 ]; then
-		fails=$(($fails+1))
-		thisFail=1
-	fi
-	if [ $thisFail -eq 1 ]; then
-		failStr=' FAIL'
+  check_selection $testSuite $testNo $outDir $CI_CONCURRENT_ID
+
+  if [ $? -ne 0 ]; then
+    fails=$(($fails + 1))
+    thisFail=1
+  fi
+  if [ $thisFail -eq 1 ]; then
+    failStr=' FAIL'
     # In case of error, print the log file
     cat $logFile
-	else
-		failStr=' PASS'
-	fi
-	echo -e "\n[ --------------------------------- ] \n" >> "$logFile"
-	echo "Running PGIS Integration Test $testNo : $testFile | $failStr"
+  else
+    failStr=' PASS'
+  fi
+  echo -e "\n[ --------------------------------- ] \n" >>"$logFile"
+  echo "Running PGIS Integration Test $testNo : $testFile | $failStr"
 done
 
 echo "Failed tests: $fails"
 exit $fails
-


### PR DESCRIPTION
This formats all shell scripts via shfmt to generate a common look-and-feel of the scripts when it comes to formatting.

The command used: `shfmt -i 2 -w $file`