### PR TITLE
Make headers public to help transitively dependent client programs

### DIFF
--- a/cmake/json.cmake
+++ b/cmake/json.cmake
@@ -25,5 +25,5 @@ else()
 endif()
 
 function(add_json target)
-  target_link_libraries(${target} PRIVATE nlohmann_json::nlohmann_json)
+  target_link_libraries(${target} PUBLIC nlohmann_json::nlohmann_json)
 endfunction()

--- a/cmake/spdlog.cmake
+++ b/cmake/spdlog.cmake
@@ -20,5 +20,5 @@ if(DEFINED spdlog_SOURCE_DIR)
 endif()
 
 function(add_spdlog_libraries target)
-  target_link_libraries(${target} PRIVATE spdlog::spdlog)
+  target_link_libraries(${target} PUBLIC spdlog::spdlog)
 endfunction()


### PR DESCRIPTION
Client tools currently need to link to spdlog and nlohman themselves as we expose some of their includes in header files.
This changes the linkage status inside cmake to be public to hopefully remove this problem