### PR TITLE
Revert "Make headers public to help transitively dependent client programs"

### DIFF
--- a/cmake/json.cmake
+++ b/cmake/json.cmake
@@ -25,5 +25,5 @@ else()
 endif()
 
 function(add_json target)
-  target_link_libraries(${target} PUBLIC nlohmann_json::nlohmann_json)
+  target_link_libraries(${target} PRIVATE nlohmann_json::nlohmann_json)
 endfunction()

--- a/cmake/spdlog.cmake
+++ b/cmake/spdlog.cmake
@@ -20,5 +20,5 @@ if(DEFINED spdlog_SOURCE_DIR)
 endif()
 
 function(add_spdlog_libraries target)
-  target_link_libraries(${target} PUBLIC spdlog::spdlog)
+  target_link_libraries(${target} PRIVATE spdlog::spdlog)
 endfunction()


### PR DESCRIPTION
Reverts tudasc/MetaCG#35

Internal testing has shown problems with installing metacg after this patch has landed.
Reverting for now