### PR TITLE
Fix cgmerge to handle call graphs with null meta field

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -20,6 +20,5 @@ Tim Heldmann <Scientific Computing>
 Marek Beckmann <Scientific Computing>
 Silas Martens <Scientific Computing>
 
-
 External Contributors
 Jan-Patrick Lehr <AMD>

--- a/cgcollector/lib/src/JSONManager.cpp
+++ b/cgcollector/lib/src/JSONManager.cpp
@@ -170,8 +170,11 @@ nlohmann::json buildFromJSONv2(FuncMapT& functionMap, const std::string& filenam
     auto ps = it.value()["callers"].get<std::set<std::string>>();
     fi.parents.insert(ps.begin(), ps.end());
 
-    readNumStmts(it.value(), fi);
-    readFileOrigin(it.value(), fi);
+    if(!it.value()["meta"].is_null()) {
+      readNumStmts(it.value(), fi);
+      readFileOrigin(it.value(), fi);
+    }
+
   }
 
   // Now the functions map holds all the information

--- a/cgcollector/tools/CGMerge.cpp
+++ b/cgcollector/tools/CGMerge.cpp
@@ -73,9 +73,12 @@ nlohmann::json mergeFileFormatTwo(const std::string& wholeCGFilename, const std:
       } else {
         auto& c = wholeCG[it.key()];
         auto& v = it.value();
+        if (v["meta"].is_null()) {
+          doMerge(c, v); // skip merging metadata
+
         // TODO multiple bodies possible, if the body is in header?
         // TODO separate merge of meta information
-        if (v["hasBody"].get<bool>() && c["hasBody"].get<bool>()) {
+        } else if (v["hasBody"].get<bool>() && c["hasBody"].get<bool>()) {
           // std::cout << "WARNING: merge of " << it.key()
           //          << " has detected multiple bodies (equal number of statements would be good.)" << std::endl;
           // TODO check for equal values
@@ -105,10 +108,11 @@ nlohmann::json mergeFileFormatTwo(const std::string& wholeCGFilename, const std:
           // callees, isVirtual, doesOverride and overriddenFunctions unchanged
           // hasBody unchanged
           // numStatements unchanged
-        } else {
-          // nothing special
-        }
-        if (!c["meta"].contains("estimateCallCount") && v["meta"].contains("estimateCallCount")) {
+        } 
+        
+        if (c["meta"].is_null()) {
+          // Metadata is null, nothing to merge
+        } else if (!c["meta"].contains("estimateCallCount") && v["meta"].contains("estimateCallCount")) {
           c["meta"]["estimateCallCount"] = v["meta"]["estimateCallCount"];
         } else if (c["meta"].contains("estimateCallCount") && v["meta"].contains("estimateCallCount")) {
           auto& ccalls = c["meta"]["estimateCallCount"]["calls"];


### PR DESCRIPTION
`CGMerge` can now handle call graphs where the meta field is null. This is necessary to merge the patch graphs generated by `cgpatch`.