### PR TITLE
Change json and spdlog into public dependencies of the graphlib

### DIFF
--- a/graph/CMakeLists.txt
+++ b/graph/CMakeLists.txt
@@ -111,8 +111,8 @@ endif()
 
 add_config_include(metacg)
 
-add_json(metacg)
-add_spdlog_libraries(metacg)
+target_link_libraries(metacg PUBLIC nlohmann_json::nlohmann_json)
+target_link_libraries(metacg PUBLIC spdlog::spdlog)
 
 if(METACG_BUILD_UNIT_TESTS)
   add_subdirectory(test/unit)

--- a/tools/cgconvert/CMakeLists.txt
+++ b/tools/cgconvert/CMakeLists.txt
@@ -4,7 +4,6 @@ set(TARGETS_EXPORT_NAME ${PROJECT_NAME}-target)
 add_executable(cgconvert CGConvert.cpp)
 
 add_metacg(cgconvert)
-add_spdlog_libraries(cgconvert)
 
 install(
   TARGETS cgconvert

--- a/tools/cgmerge2/CMakeLists.txt
+++ b/tools/cgmerge2/CMakeLists.txt
@@ -4,9 +4,7 @@ set(TARGETS_EXPORT_NAME ${PROJECT_NAME}-target)
 add_executable(cgmerge2 CGMerge2.cpp)
 
 add_config_include(cgmerge2)
-add_json(cgmerge2)
 add_metacg(cgmerge2)
-add_spdlog_libraries(cgmerge2)
 add_clang(cgmerge2)
 
 install(

--- a/tools/cgpatch/CMakeLists.txt
+++ b/tools/cgpatch/CMakeLists.txt
@@ -26,8 +26,6 @@ foreach(tgt cgpatch-call-analysis cgpatch-inst-pass)
 endforeach()
 
 add_metacg(cgpatch-inst-pass)
-add_spdlog_libraries(cgpatch-inst-pass)
-add_json(cgpatch-inst-pass)
 
 install(TARGETS cgpatch-inst-pass LIBRARY DESTINATION lib)
 


### PR DESCRIPTION
JSON and spdlog are both included in certain MetaCG headers. Any tool using MetaCG, therefore, requires them to be in the include path.
This patch adds them to the public interface, thus simplifying the setup for downstream tools.