### PR TITLE
Replaced error with warning when CGPatch is built with llvm < 15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ if(METACG_BUILD_CGPATCH)
   )
     add_subdirectory(tools/cgpatch/)
   else()
-    message(FATAL_ERROR "CGPatch requires LLVM version 15 or higher")
+    message(STATUS "Skipping CGPatch: requires LLVM version 15 or higher")
   endif()
 endif()
 # PIRA analyzer Should PGIS be built


### PR DESCRIPTION
 Disable CGPatch build for LLVM < 15 instead of failing with error