### PR TITLE
Performance testing

### DIFF
--- a/graph/CMakeLists.txt
+++ b/graph/CMakeLists.txt
@@ -119,3 +119,4 @@ if(METACG_BUILD_UNIT_TESTS)
 endif()
 
 add_subdirectory(test/integration/CallgraphMerge)
+add_subdirectory(test/integration/Performance)

--- a/graph/test/integration/Performance/CMakeLists.txt
+++ b/graph/test/integration/Performance/CMakeLists.txt
@@ -1,0 +1,9 @@
+set(PROJECT_NAME PerfTest)
+set(TARGETS_EXPORT_NAME ${PROJECT_NAME}-target)
+
+add_executable(perftest PerfTester.cpp)
+target_link_libraries(perftest PUBLIC metacg::metacg)
+
+add_json(perftest)
+add_spdlog_libraries(perftest)
+add_config_include(perftest)

--- a/graph/test/integration/Performance/PerfTester.cpp
+++ b/graph/test/integration/Performance/PerfTester.cpp
@@ -1,0 +1,179 @@
+/**
+ * File: PerfTester.cpp
+ * License: Part of the MetaCG project. Licensed under BSD 3 clause license. See LICENSE.txt file at
+ * https://github.com/tudasc/metacg/LICENSE.txt
+ */
+
+#include "Callgraph.h"
+#include "io/MCGReader.h"
+#include "io/MCGWriter.h"
+
+#include <chrono>
+#include <functional>
+#include <random>
+
+using namespace metacg;
+
+class Timer {
+ public:
+  using Clock = std::chrono::high_resolution_clock;
+  using TP = Clock::time_point;
+  using Duration = Clock::duration;
+
+  explicit Timer() {start();};
+
+  void start() { startTime = Clock::now();}
+
+  void stop() { endTime = Clock::now(); }
+
+  std::chrono::milliseconds getElapsedMillis() {
+    auto dur = endTime - startTime;
+    auto durInMillis = std::chrono::duration_cast<std::chrono::milliseconds>(dur);
+    return durInMillis;
+  }
+
+ private:
+  TP startTime;
+  TP endTime;
+};
+
+using PerfResults = std::unordered_map<std::string, size_t>;
+
+class PerfTester {
+ public:
+  explicit PerfTester(int seed, int numNodes, int numEdges) : seed(seed), numNodes(numNodes), numEdges(numEdges), rng(seed) {}
+
+  PerfResults run();
+
+ private:
+  template<typename Fn, typename... ArgT>
+  void runPerfTest(PerfResults&, const std::string&, Fn&& testFn, ArgT&&... args);
+
+  void insertNodes(Callgraph& cg, int num);
+  void insertEdges(Callgraph& cg, int num);
+  void write(Callgraph& cg, io::JsonSink& sink, int version);
+  void read(std::unique_ptr<Callgraph>& cg, io::JsonSource& source);
+
+ private:
+  int seed;
+  int numNodes;
+  int numEdges;
+  std::mt19937 rng;
+};
+
+PerfResults PerfTester::run() {
+  using namespace std::placeholders;
+
+  PerfResults results;
+
+  auto cg = std::make_unique<Callgraph>();
+  auto insertTest = std::bind(&PerfTester::insertNodes, *this, _1, _2);
+  auto insertEdges = std::bind(&PerfTester::insertEdges, *this, _1, _2);
+  runPerfTest(results, "insert nodes", insertTest, *cg, numNodes);
+  runPerfTest(results, "insert edges", insertEdges, *cg, numEdges);
+
+  auto writeTest = std::bind(&PerfTester::write, *this, _1, _2, _3);
+  io::JsonSink v3Sink;
+  runPerfTest(results, "write V3 format", writeTest, *cg, v3Sink, 3);
+
+  auto readTest = std::bind(&PerfTester::read, *this, _1, _2);
+  std::unique_ptr<Callgraph> readCg;
+  auto v3Source = io::JsonSource(v3Sink.getJson());
+  runPerfTest(results, "read V3 format", readTest, readCg, v3Source);
+
+  io::JsonSink v2Sink;
+  runPerfTest(results, "write V2 format", writeTest, *cg, v2Sink, 2);
+
+  std::unique_ptr<Callgraph> readCg2;
+  auto v2Source = io::JsonSource(v2Sink.getJson());
+  runPerfTest(results, "read V2 format", readTest, readCg, v2Source);
+
+  return results;
+}
+
+template<typename Fn, typename... ArgT>
+void PerfTester::runPerfTest(PerfResults& results, const std::string& name, Fn&& testFn, ArgT&&... args) {
+  std::cout  << "Running performance test: " << name << "\n";
+  Timer timer;
+  testFn(std::forward<ArgT>(args)...);
+  timer.stop();
+  results[name] = timer.getElapsedMillis().count();
+}
+
+void PerfTester::insertNodes(Callgraph& cg, int num) {
+  for (int i = 0; i < num; i++) {
+    cg.insert("function" + std::to_string(i));
+  }
+  assert(cg.size() == num && "Size of CG does not match inserted nodes");
+}
+
+void PerfTester::insertEdges(Callgraph& cg, int num) {
+  std::uniform_int_distribution<> dist(0, cg.size()-1);
+  auto& nodes = cg.getNodes();
+  for (int i = 0; i < num; i++) {
+    auto name1 = "function" + std::to_string(dist(rng));
+    auto name2 = "function" + std::to_string(dist(rng));
+    auto node1 = cg.getNode(name1);
+    auto node2 = cg.getNode(name2);
+    assert(node1 && node2 && "Node does not exist");
+    cg.addEdge(node1, node2);
+  }
+}
+
+void PerfTester::write(Callgraph& cg, io::JsonSink& sink, int version) {
+  auto writer = io::createWriter(version);
+  assert(writer && "Writer is null");
+  writer->write(&cg, sink);
+}
+
+void PerfTester::read(std::unique_ptr<Callgraph>& cg, io::JsonSource& source) {
+  auto reader = io::createReader(source);
+  cg = std::move(reader->read());
+}
+
+
+
+int main(int argc, const char** argv) {
+  int numNodes = 10000;
+  int numEdges = 20000;
+  int seed = 463248923;
+  if (argc > 1) {
+    numNodes = std::stoi(argv[1]);
+    if (argc > 2) {
+      numEdges = std::stoi(argv[2]);
+      if (argc > 3) {
+        seed = std::stoi(argv[3]);
+      }
+    } else {
+      numEdges = numNodes;
+    }
+  }
+
+  PerfTester perfTest(seed, numNodes, numEdges);
+  auto results = perfTest.run();
+
+  // Determine column widths
+  size_t nameWidth = 0;
+  for (const auto& [test, _] : results) {
+    nameWidth = std::max(nameWidth, test.size());
+  }
+  nameWidth = std::max(nameWidth, std::string("Test Name").size());
+
+  std::cout << "Test results for " << numNodes << " nodes and " << numEdges << " edges (seed: " << seed << ")\n";
+  // Print header
+  std::cout << std::string(nameWidth + 2 + 10, '-') << "\n";
+  std::cout << std::left << std::setw(nameWidth + 2) << "Test Name"
+            << std::right << std::setw(10) << "Time (ms)" << "\n";
+  std::cout << std::string(nameWidth + 2 + 10, '-') << "\n";
+
+  // Print rows
+  for (const auto& [test, millis] : results) {
+    std::cout << std::left << std::setw(nameWidth + 2) << test
+              << std::right << std::setw(10) << millis << "\n";
+  }
+  std::cout << std::string(nameWidth + 2 + 10, '-') << "\n";
+
+
+
+  return 0;
+}


### PR DESCRIPTION
This adds performance tests for the graph lib. I wrote this as a weekend project to be able to evaluate the performance differences of the upcoming graphlib re-write.
 As a follow-up, this can be integrated into the CI to catch performance regressions.
 
 Usage: `./perftest <num_nodes> <num_edges> <rng_seed>`

Results for current `devel` on my laptop: 
```
Test results for 10000 nodes and 20000 edges (seed: 463248923)
---------------------------
Test Name         Time (ms)
---------------------------
read V2 format        40736
write V2 format         866
read V3 format          230
write V3 format         580
insert edges            131
insert nodes             31
---------------------------
```