### PR TITLE
Remove support and downstream testing for GCC 10

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -17,9 +17,6 @@ stages:
 .job-setup: &job-setup
   parallel:
     matrix:
-      - GCC: 10
-        #LLVM: [10.0.1, 11.1.0, 12.0.1, 13.0.0, 14.0.0]
-        LLVM: [10.0.1, 14.0.6]
       - GCC: 11
         LLVM: [13.0.1, 14.0.6, 15.0.7, 16.0.6, 17.0.6, 18.1.8]
   variables:

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Refer to the [pymetacg README](pymetacg/README.md) for more information how to b
 MetaCG consists of the graph library, a CG construction tool, and an example analysis tool.
 The graph library is always built, while the CGCollector and the PGIS tool can be disabled at configure time.
 
-We test MetaCG internally using GCC 10 and 11 for Clang 10 and 14 (for GCC 10) and 13 and 14 (for GCC 11), respectively.
+We test MetaCG internally using GCC 11 for Clang/LLVM 13, 14, 15, 16, 17 and 18.
 Other version combinations *may* work.
 
 **Build Requirements (for graph lib)**


### PR DESCRIPTION
GCC 10 is around 5 years old by now and, as far as we're currently aware, not a default compiler for any major distribution. Currently, we still test MetaCG using GCC 10 in our downstream CI, but the build are currently failing due a template resolution problem in pymetacg. As briefly discussed during one of our past meetings, I propose to drop support for GCC 10, but would be open to expanding the range of GCC versions again when we move the CI to the new module system on Lichtenberg.