### PR TITLE
Add install rules for public dependencies

### DIFF
--- a/cmake/install-config.cmake
+++ b/cmake/install-config.cmake
@@ -1,1 +1,4 @@
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+
 include("${CMAKE_CURRENT_LIST_DIR}/metacgTargets.cmake")

--- a/cmake/installRules.cmake
+++ b/cmake/installRules.cmake
@@ -79,6 +79,10 @@ install(
   COMPONENT metacg_Development
 )
 
+# Install public graph library dependencies
+install(TARGETS nlohmann_json spdlog
+        EXPORT metacgTargets)
+
 # Install the generated CustomMD.h header
 install(
   FILES ${PROJECT_BINARY_DIR}/graph/include/metadata/CustomMD.h

--- a/cmake/installRules.cmake
+++ b/cmake/installRules.cmake
@@ -80,8 +80,7 @@ install(
 )
 
 # Install public graph library dependencies
-install(TARGETS nlohmann_json spdlog
-        EXPORT metacgTargets)
+install(TARGETS nlohmann_json spdlog EXPORT metacgTargets)
 
 # Install the generated CustomMD.h header
 install(

--- a/cmake/json.cmake
+++ b/cmake/json.cmake
@@ -25,5 +25,5 @@ else()
 endif()
 
 function(add_json target)
-  target_link_libraries(${target} PRIVATE nlohmann_json::nlohmann_json)
+  target_link_libraries(${target} PUBLIC nlohmann_json::nlohmann_json)
 endfunction()

--- a/cmake/spdlog.cmake
+++ b/cmake/spdlog.cmake
@@ -20,5 +20,5 @@ if(DEFINED spdlog_SOURCE_DIR)
 endif()
 
 function(add_spdlog_libraries target)
-  target_link_libraries(${target} PRIVATE spdlog::spdlog)
+  target_link_libraries(${target} PUBLIC spdlog::spdlog)
 endfunction()

--- a/graph/CMakeLists.txt
+++ b/graph/CMakeLists.txt
@@ -110,9 +110,8 @@ if(NOT CMAKE_SKIP_INSTALL_RULES)
 endif()
 
 add_config_include(metacg)
-
-target_link_libraries(metacg PUBLIC nlohmann_json::nlohmann_json)
-target_link_libraries(metacg PUBLIC spdlog::spdlog)
+add_json(metacg)
+add_spdlog_libraries(metacg)
 
 if(METACG_BUILD_UNIT_TESTS)
   add_subdirectory(test/unit)

--- a/graph/test/integration/CallgraphMerge/CMakeLists.txt
+++ b/graph/test/integration/CallgraphMerge/CMakeLists.txt
@@ -2,16 +2,12 @@ set(PROJECT_NAME CallgraphMergeIntegrationTest)
 set(TARGETS_EXPORT_NAME ${PROJECT_NAME}-target)
 
 add_library(MergeMD SHARED MergeCountMD.cpp)
-add_json(MergeMD)
 add_metacg(MergeMD)
-add_spdlog_libraries(MergeMD)
 
 add_executable(mergetester MergeTester.cpp)
 target_include_directories(mergetester PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 target_link_libraries(mergetester PUBLIC metacg::metacg)
 
-add_json(mergetester)
-add_spdlog_libraries(mergetester)
 add_config_include(mergetester)
 
 add_test(NAME mergeTests COMMAND mergetester)

--- a/graph/test/integration/Performance/CMakeLists.txt
+++ b/graph/test/integration/Performance/CMakeLists.txt
@@ -2,8 +2,7 @@ set(PROJECT_NAME PerfTest)
 set(TARGETS_EXPORT_NAME ${PROJECT_NAME}-target)
 
 add_executable(perftest PerfTester.cpp)
-target_link_libraries(perftest PUBLIC metacg::metacg)
+add_metacg(perftest)
 
-add_json(perftest)
-add_spdlog_libraries(perftest)
+
 add_config_include(perftest)

--- a/graph/test/integration/Performance/CMakeLists.txt
+++ b/graph/test/integration/Performance/CMakeLists.txt
@@ -4,5 +4,4 @@ set(TARGETS_EXPORT_NAME ${PROJECT_NAME}-target)
 add_executable(perftest PerfTester.cpp)
 add_metacg(perftest)
 
-
 add_config_include(perftest)

--- a/graph/test/unit/CMakeLists.txt
+++ b/graph/test/unit/CMakeLists.txt
@@ -18,10 +18,8 @@ add_executable(
 
 target_include_directories(libtests PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 add_googletest_libraries(libtests)
-target_link_libraries(libtests PUBLIC metacg::metacg)
+add_metacg(libtests)
 
-add_json(libtests)
-add_spdlog_libraries(libtests)
 add_config_include(libtests)
 
 add_test(NAME libraryTests COMMAND libtests)

--- a/pgis/lib/CMakeLists.txt
+++ b/pgis/lib/CMakeLists.txt
@@ -31,12 +31,9 @@ set(PGIS_LIB_SOURCES
 add_library(pgis SHARED ${PGIS_LIB_SOURCES})
 
 add_pgis_includes(pgis)
-add_graph_includes(pgis)
-add_metacg_library(pgis)
+add_metacg(pgis)
 add_cube(pgis)
 add_extrap(pgis)
-add_spdlog_libraries(pgis)
-add_json(pgis)
 target_project_compile_options(pgis)
 
 install(

--- a/pgis/test/unit/CMakeLists.txt
+++ b/pgis/test/unit/CMakeLists.txt
@@ -14,8 +14,6 @@ add_executable(
 add_googletest_libraries(pgistests)
 add_pgis(pgistests)
 add_metacg(pgistests)
-add_json(pgistests)
-add_spdlog_libraries(pgistests)
 
 # add_library(ipcg) target_link_libraries(pgistests)
 

--- a/pgis/tool/CMakeLists.txt
+++ b/pgis/tool/CMakeLists.txt
@@ -7,8 +7,6 @@ add_executable(pgis_pira PGISMain.cpp)
 add_pgis(pgis_pira)
 add_cxxopts(pgis_pira)
 add_cube(pgis_pira)
-add_json(pgis_pira)
-add_spdlog_libraries(pgis_pira)
 add_metacg(pgis_pira)
 
 install(

--- a/pymetacg/CMakeLists.txt
+++ b/pymetacg/CMakeLists.txt
@@ -16,8 +16,6 @@ nanobind_strip(pymetacg)
 nanobind_disable_stack_protector(pymetacg)
 
 add_metacg_library(pymetacg)
-add_spdlog_libraries(pymetacg)
-add_json(pymetacg)
 
 if(NOT CMAKE_INSTALL_PYTHON_LIBDIR)
   set(CMAKE_INSTALL_PYTHON_LIBDIR

--- a/pymetacg/tests/CMakeLists.txt
+++ b/pymetacg/tests/CMakeLists.txt
@@ -10,9 +10,7 @@ find_package(
 )
 
 add_library(dummy_md SHARED DummyMD.cpp)
-add_spdlog_libraries(dummy_md)
-add_json(dummy_md)
-target_link_libraries(dummy_md PRIVATE metacg::metacg)
+add_metacg(dummy_md)
 
 pytest_discover_tests(
   pymetacg_tests


### PR DESCRIPTION
We recently changed the dependency of `nlohmann_json` and `spdlog` to `PUBLIC`, which led to problems in the install tests (see #46). 
This PR fixes the issue by properly installing these dependencies alongside MetaCG. 
Additionally, it removes the now redundant dependencies in all graph lib tools and tests. 

Note that `splog` has an `INTERFACE` dependency on `Threads`. This is easily resolved with the addition of `find_dependency(Threads)` in `cmake/install-config.cmake`.

I verified that this fixes the issue by running our gitlab CI.