### PR TITLE
CGPatch Integration tests: Fix race condition in CI

### DIFF
--- a/.github/workflows/mcg-ci.yml
+++ b/.github/workflows/mcg-ci.yml
@@ -137,6 +137,6 @@ jobs:
           run: |
             export OMPI_ALLOW_RUN_AS_ROOT=1
             export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
-            cd /opt/metacg/tools/cgpatch/test/integration/
+            cd /opt/metacg/build/tools/cgpatch/test/integration/
             ./CGPIntegrationRunner.sh -d
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -313,7 +313,7 @@ test-cgpatch-integration:
   needs: ["build-mcg"]
   script:
     - module load clang/$LLVM
-    - cd tools/cgpatch/test/integration/
+    - cd $MCG_BUILD/tools/cgpatch/test/integration/
     - ./CGPIntegrationRunner.sh -b $MCG_BUILD
 
 # Stage: install

--- a/tools/cgpatch/test/integration/CGPIntegrationRunner.sh.in
+++ b/tools/cgpatch/test/integration/CGPIntegrationRunner.sh.in
@@ -7,7 +7,9 @@ function pretty {
 
 export OMPI_CXX=$(which clang++)
 
-build_dir=build # default
+build_dir=@CMAKE_BINARY_DIR@ # default
+test_root=@CMAKE_CURRENT_SOURCE_DIR@
+CGPATCH_USE_MPI=@CGPATCH_USE_MPI@
 debug=0
 
 while getopts ":b:hd" opt; do
@@ -16,7 +18,7 @@ while getopts ":b:hd" opt; do
 			if [ -z "$OPTARG" ]; then
 				echo "no build directory given, assuming \"build\""
 			fi
-			build_dir=$OPTARG
+			build_dir=$build_dir/../$OPTARG
 			;;
 		h)
 			echo "use -b to provide build directory NAME"
@@ -43,17 +45,13 @@ function log {
 fails=0
 logDir=$PWD/logging
 logFile=$logDir/cgpatch-${CI_CONCURRENT_ID}.log
-inputRoot=$PWD/input
-buildDir=$PWD/../../../../${build_dir}/
+inputRoot=$test_root/input
+buildDir=${build_dir}/
 cgpatchExe=$buildDir/tools/cgpatch/wrapper/patchcxx
 testerExe=$buildDir/tools/cgpatch/test/cgtester
 cgmerge2Exe="$buildDir/tools/cgmerge2/cgmerge2"
 outputDir=$buildDir/tools/cgpatch/test/integration
 
-# load config file, required to check if using MPI
-if [ -f "${buildDir}/tools/cgpatch/test/integration/config.sh" ]; then
-  source "${buildDir}/tools/cgpatch/test/integration/config.sh"
-fi
 
 if [ ! -d "${logDir}" ]; then
 	mkdir "${logDir}"
@@ -73,9 +71,9 @@ function build_and_run_mpi_testcase {
 	local testDir="$3"
 	local testExe="$outputDir/${testName}.out"
 	local testPG="$outputDir/${testName}.pg"
-    local testGT="$./input/mpi/{testName}.gtpg"
+    local testGT="$test_root/input/mpi/{testName}.gtpg"
 	local testMCG="$outputDir/${testName}.mcg"
-	local testSCG="./input/general/${testName}.ipcg"
+	local testSCG="$test_root/input/general/${testName}.ipcg"
 
     export CGPATCH_CG_NAME="${testPG}"
 
@@ -104,9 +102,9 @@ function build_and_run_regular_testcase {
 	local testDir="$3"
 	local testExe="$outputDir/${testName}.out"
 	local testPG="$outputDir/${testName}.pg"
-	local testGT="./input/general/${testName}.gtpg"
+	local testGT="$test_root/input/general/${testName}.gtpg"
 	local testMCG="$outputDir/${testName}.mcg"
-	local testSCG="./input/general/${testName}.ipcg"
+	local testSCG="$test_root/input/general/${testName}.ipcg"
 
     export CGPATCH_CG_NAME="${testPG}"
 
@@ -191,4 +189,5 @@ for prefix in $(collect_testcases); do
 done
 
 echo "Finished running tests. Failures: $fails"
+
 exit $fails

--- a/tools/cgpatch/test/integration/CMakeLists.txt
+++ b/tools/cgpatch/test/integration/CMakeLists.txt
@@ -1,7 +1,5 @@
-set(CONFIG_OUTPUT_PATH "${CMAKE_CURRENT_BINARY_DIR}/config.sh")
-
 configure_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/config.sh.in
-  ${CONFIG_OUTPUT_PATH}
-  @ONLY
+    ${CMAKE_CURRENT_SOURCE_DIR}/CGPIntegrationRunner.sh.in
+    ${CMAKE_CURRENT_BINARY_DIR}/CGPIntegrationRunner.sh
+    @ONLY
 )

--- a/tools/cgpatch/test/integration/config.sh.in
+++ b/tools/cgpatch/test/integration/config.sh.in
@@ -1,1 +1,0 @@
-export CGPATCH_USE_MPI="@CGPATCH_USE_MPI@"


### PR DESCRIPTION
This PR fixes a race condition in the pipeline which occurred because temporary test files were written into the source directory.

Additionally I configure the Integration test runner with CMake.