### PR TITLE
CGFormat

### DIFF
--- a/.github/workflows/mcg-ci.yml
+++ b/.github/workflows/mcg-ci.yml
@@ -113,6 +113,13 @@ jobs:
           run: |
             cd /opt/metacg/cgcollector/test/integration
             ./runner.sh build
+      - name: Run cgformat tests
+        uses: addnab/docker-run-action@v3
+        with:
+          image: metacg-devel:latest
+          run: |
+            cd /opt/metacg/build/tools/cgformat/test
+            ./run_cgformat_tests.sh
       - name: Run pymetacg tests
         uses: addnab/docker-run-action@v3
         with: 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -239,6 +239,14 @@ test-cgvalidate:
     - cd cgcollector/test/integration
     - ./runner.sh $MCG_BUILD
 
+test-cgformat:
+  <<: *job-setup
+  stage: test
+  needs: [ "build-mcg" ]
+  script:
+    - cd $MCG_BUILD/tools/cgformat/test
+    - ./run_cgformat_tests.sh
+
 test-basic-pgis:
   <<: *job-setup
   stage: integration-test

--- a/graph/include/io/MCGReader.h
+++ b/graph/include/io/MCGReader.h
@@ -103,6 +103,8 @@ struct JsonSource : ReaderSource {
  */
 class MetaCGReader {
  public:
+  using MetadataCB = std::function<void(NodeId, const std::string&, nlohmann::json&)>;
+
   /**
    * filename path to file
    */
@@ -115,11 +117,24 @@ class MetaCGReader {
    */
   [[nodiscard]] virtual std::unique_ptr<Callgraph> read() = 0;
 
+  /**
+   * Registers a callback that will be invoked, when reading metadata fails.
+   * Note that only one callback can be registered.
+   * Pass an empty optional to disable the callback.
+   * @param cb Callback function taking the ID of the currently processed node, the metadata type and
+   * corresponding json.
+   */
+  void onFailedMetadataRead(std::optional<MetadataCB> cb) {
+    this->failedMetadataCb = cb;
+  }
+
  protected:
   /**
    * Abstraction from where to read-in the JSON.
    */
   ReaderSource& source;
+
+  std::optional<MetadataCB> failedMetadataCb;
 
  private:
   // filename of the metacg this instance parses

--- a/graph/src/io/VersionFourMCGReader.cpp
+++ b/graph/src/io/VersionFourMCGReader.cpp
@@ -173,6 +173,8 @@ std::unique_ptr<metacg::Callgraph> metacg::io::VersionFourMetaCGReader::read() {
           auto& mdValJ = mdElem.value();
           if (auto md = metacg::MetaData::create<>(mdKey, mdValJ, strToNode); md) {
             cg->addEdgeMetaData({nodeData.nodeId, calleeNode->getId()}, std::move(md));
+          } else if (failedMetadataCb) {
+            (*failedMetadataCb)(nodeData.nodeId, mdKey, mdValJ);
           }
         }
       }
@@ -185,6 +187,9 @@ std::unique_ptr<metacg::Callgraph> metacg::io::VersionFourMetaCGReader::read() {
         node->addMetaData(std::move(md));
       } else {
         errConsole->warn("Could not create metadata of type {} for node {}", mdKey, node->getFunctionName());
+        if (failedMetadataCb) {
+          (*failedMetadataCb)(node->getId(), mdKey, mdVal);
+        }
       }
     }
   }

--- a/graph/src/io/VersionTwoMCGReader.cpp
+++ b/graph/src/io/VersionTwoMCGReader.cpp
@@ -63,6 +63,7 @@ std::unique_ptr<metacg::Callgraph> metacg::io::VersionTwoMetaCGReader::read() {
 
   JsonSource v4JsonSrc(j);
   VersionFourMetaCGReader v4Reader(v4JsonSrc);
+  v4Reader.onFailedMetadataRead(this->failedMetadataCb);
   return v4Reader.read();
 }
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(cgmerge2)
 add_subdirectory(cgconvert)
+add_subdirectory(cgformat)

--- a/tools/README.md
+++ b/tools/README.md
@@ -31,7 +31,23 @@ Example:
 LD_PRELOAD="MyCustomMD.so" cgmerge2 merged.mcg in_A.mcg in_B.mcg
 ```
 
+## CGFormat
 
+CGFormat is a utility tool created to help check and automatically correct the formatting of MetaCG call graphs.
 
+Basic usage: `cgformat <input_file> [--apply -o <output_file>]`
+See `cgformat --help` for a full documentation of input parameters.
+Without `--apply`, `cgformat` checks the graph according to the given rules and returns a status code.
+With `--apply`, a modified version of the graph is stored in the given output file.
+If no output file is specified, the input file is overwritten.
 
+There are some safety mechanism in place, to prevent the loss of metadata in the case that some metadata entries cannot 
+be parsed.
+By default, `cgformat` will exit with an error if any metadata would be lost during the export with `--apply`.
+This behavior can be overridden with `--discard_failed_metadata`.
 
+### Example use cases
+- Checking that origin paths start with a specific prefix: `cgformat input.mcg --origin_prefix "/opt/metacg"`
+- Replacing origin path prefixes: `cgformat input.mcg --origin_prefix "/opt/metacg" --origin_prefix_to_replace "oldpath" --apply -o output.mcg`
+- Changing indentation to 4: `cgformat input.mcg --apply --indent 4`
+- Removing all indentation and new lines: `cgformat input.mcg --apply --indent '-1'`

--- a/tools/cgformat/CGFormat.cpp
+++ b/tools/cgformat/CGFormat.cpp
@@ -1,0 +1,160 @@
+/**
+ * File: CGFormat.cpp
+ * License: Part of the MetaCG project. Licensed under BSD 3 clause license. See LICENSE.txt file at
+ * https://github.com/tudasc/metacg/LICENSE.txt
+ */
+
+#include "config.h"
+
+#include <iostream>
+#include <fstream>
+#include <string>
+
+#include "LoggerUtil.h"
+#include "io/MCGReader.h"
+#include "io/MCGWriter.h"
+
+#include "cxxopts.hpp"
+
+using namespace metacg;
+
+static std::optional<std::string> replacePathPrefix(const std::string& originalPath,
+                                const std::string& targetDir,
+                                const std::string& newPrefix) {
+  std::string search = "/" + targetDir;
+  size_t pos = originalPath.find(search);
+  if (pos == std::string::npos) {
+    return std::nullopt;
+  }
+  size_t afterTarget = pos + search.length();
+
+  std::string new_path = newPrefix + originalPath.substr(afterTarget);
+  return new_path;
+}
+
+int main(int argc, char** argv) {
+  MCGLogger::logInfo("Running metacg::CGFormat (version {}.{})\nGit revision: {}", MetaCG_VERSION_MAJOR,
+                     MetaCG_VERSION_MINOR, MetaCG_GIT_SHA);
+
+  // clang-format off
+  cxxopts::Options options("cgformat", "Formatting and canonicalization of MetaCG files");
+  options.add_options()("input", "input MetaCG file", cxxopts::value<std::string>())(
+      "o,output", "output file (default is to overwrite)", cxxopts::value<std::string>()->default_value(""))(
+      "apply", "apply formatting and canonicalization", cxxopts::value<bool>()->default_value("false"))(
+      "abort_after_error", "abort checking after the first error", cxxopts::value<bool>()->default_value("false"))(
+      "origin_prefix", "check for a specific path prefix in the origin field", cxxopts::value<std::string>()->default_value(""))(
+      "origin_prefix_to_replace", "marks the directory in the origin path that will be replaced by the prefix given in 'origin_prefix'", cxxopts::value<std::string>()->default_value(""))(
+      "indent", "number of spaced used for indentation of the file. A value of -1 disables pretty-printing.", cxxopts::value<int>()->default_value("4"))(
+      "discard_failed_metadata", "continue formatting, even if there is metadata that cannot be parsed and would be lost.", cxxopts::value<bool>()->default_value("false"))(
+      "h,help", "Print help");
+  // clang-format on
+
+  options.parse_positional("input");
+
+  const cxxopts::ParseResult result = options.parse(argc, argv);
+
+  if (result.count("help")) {
+    std::cout << options.help({""}) << std::endl;
+    return EXIT_SUCCESS;
+  }
+
+  std::string inputFile = result["input"].as<std::string>();
+  std::string outputFile = result["output"].as<std::string>();
+  if (outputFile.empty()) {
+    outputFile = inputFile;
+  }
+  bool overwriting = inputFile == outputFile;
+  int indent = result["indent"].as<int>();
+  std::string originPrefix = result["origin_prefix"].as<std::string>();
+  std::string prefixToReplace = result["origin_prefix_to_replace"].as<std::string>();
+  bool checkOnly = !result["apply"].as<bool>();
+  bool discardFailedMd = result["discard_failed_metadata"].as<bool>();
+  bool abortCheckAfterError = result["abort_after_error"].as<bool>();
+
+  io::FileSource fs(inputFile);
+
+  std::unordered_set<std::string> failedToRead;
+
+  auto mcgReader = io::createReader(fs);
+  mcgReader->onFailedMetadataRead([&failedToRead](NodeId, const std::string mdKey, nlohmann::json& mdVal) {
+    failedToRead.insert(mdKey);
+  });
+  auto graph = mcgReader->read();
+
+  bool checkSucceeded = true;
+
+  // Checking for expected origin prefix
+  if (!originPrefix.empty()) {
+    for (auto& node : graph->getNodes()) {
+      if (auto origin = node->getOrigin(); origin) {
+        if (origin->empty()) {
+          if (checkOnly) {
+            MCGLogger::logError("Found empty origin field in node {} ('{}'). Use null instead.", node->getId(), node->getFunctionName());
+            checkSucceeded = false;
+            if (abortCheckAfterError) {
+              return EXIT_FAILURE;
+            }
+          } else {
+            node->setOrigin(std::nullopt);
+          }
+        } else {
+          // This can be done with "starts_with" in C++20
+          if (origin->size() < originPrefix.size() || origin->compare(0, originPrefix.size(), originPrefix) != 0) {
+            if (checkOnly) {
+              MCGLogger::logError("Origin field in node {} ('{}') does not match expected prefix. Value is: {}", node->getId(), node->getFunctionName(), *origin);
+              checkSucceeded = false;
+              if (abortCheckAfterError) {
+                return EXIT_FAILURE;
+              }
+            } else if (!prefixToReplace.empty()) {
+              auto newOrigin = replacePathPrefix(*origin, prefixToReplace, originPrefix);
+              if (newOrigin) {
+                node->setOrigin(newOrigin);
+              } else {
+                MCGLogger::logWarn("Unable to automatically replace prefix in origin path of node {} ('{}'): {}", node->getId(), node->getFunctionName(), *origin);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // If we're only running a check, we're done here.
+  if (checkOnly) {
+    return checkSucceeded ? EXIT_SUCCESS : EXIT_FAILURE;
+  }
+
+  // We abort if metadata would be lost, unless --discard_failed_metadata is set.
+  // We always abort if the original file is to be overwritten.
+  if (!failedToRead.empty()) {
+    MCGLogger::logWarn("Some of the metadata entries could not be parsed.");
+
+    if (!discardFailedMd) {
+      MCGLogger::logError("Aborting export");
+      return EXIT_FAILURE;
+    }
+    if (overwriting) {
+      MCGLogger::logError("Please choose another output file to export with lost metadata");
+      return EXIT_FAILURE;
+    }
+    MCGLogger::logWarn("Continuing with export - some of the metadata might be lost");
+  }
+
+
+  int outputMcgVersion = std::stoi(fs.getFormatVersion());
+
+  auto mcgWriter = io::createWriter(outputMcgVersion);
+  if (!mcgWriter) {
+    MCGLogger::logError("Unable to create a writer for format version {}", outputMcgVersion);
+    return EXIT_FAILURE;
+  }
+
+  io::JsonSink jsonSink;
+  mcgWriter->write(graph.get(), jsonSink);
+
+  std::ofstream os(outputFile);
+  os << jsonSink.getJson().dump(indent) << std::endl;
+
+  return EXIT_SUCCESS;
+}

--- a/tools/cgformat/CMakeLists.txt
+++ b/tools/cgformat/CMakeLists.txt
@@ -1,0 +1,23 @@
+set(PROJECT_NAME CGFormat)
+set(TARGETS_EXPORT_NAME ${PROJECT_NAME}-target)
+
+include(cxxopts)
+
+add_executable(cgformat CGFormat.cpp)
+add_metacg(cgformat)
+add_cxxopts(cgformat)
+
+install(
+  TARGETS cgformat
+  EXPORT ${TARGETS_EXPORT_NAME}
+  RUNTIME DESTINATION bin
+)
+
+configure_package_config_file(
+  ${METACG_Directory}/cmake/Config.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+  INSTALL_DESTINATION lib/cmake
+)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake DESTINATION lib/cmake)
+
+add_subdirectory(test)

--- a/tools/cgformat/test/CGTester.cpp
+++ b/tools/cgformat/test/CGTester.cpp
@@ -1,0 +1,55 @@
+#include "nlohmann/json.hpp"
+
+#include <fstream>
+#include <iostream>
+
+bool check(nlohmann::json testGraph, nlohmann::json groundTruth) {
+  for (auto& elem : groundTruth.at("_CG")) {
+    for (auto& member : elem) {
+      if (member.is_array()) {
+        std::sort(member.begin(), member.end());
+      }
+    }
+  }
+
+  for (auto& elem : testGraph.at("_CG")) {
+    for (auto& member : elem) {
+      if (member.is_array()) {
+        std::sort(member.begin(), member.end());
+      }
+    }
+  }
+
+  return groundTruth.at("_CG") == testGraph.at("_CG");
+}
+
+int main(int argc, char** argv) {
+  if (argc != 3) {
+    std::cerr << "Usage: " << argv[0] << " groundtruth.json collector-result.ipcg" << std::endl;
+    return -1;
+  }
+
+  std::cout << "Running test for " << argv[1] << " == " << argv[2] << std::endl;
+
+  nlohmann::json groundTruth;
+  {
+    std::ifstream file(argv[1]);
+    file >> groundTruth;
+  }
+
+  nlohmann::json collectorResult;
+  {
+    std::ifstream file(argv[2]);
+    file >> collectorResult;
+  }
+
+  if (check(groundTruth, collectorResult)) {
+    std::cout << "Test success" << std::endl;
+
+    return 0;
+  } else {
+    std::cerr << "Test failure" << std::endl;
+
+    return 1;
+  }
+}

--- a/tools/cgformat/test/CMakeLists.txt
+++ b/tools/cgformat/test/CMakeLists.txt
@@ -1,0 +1,28 @@
+add_executable(cgformat_tester CGTester.cpp)
+add_json(cgformat_tester)
+
+
+macro(make_executable input output)
+    # Executable permission: In CMAKE 3.19 we can simply use file(CHMOD) instead of file(copy) workaround
+    configure_file(${input} ${CMAKE_CURRENT_BINARY_DIR}/tmp/${output} @ONLY)
+    file(
+            COPY ${CMAKE_CURRENT_BINARY_DIR}/tmp/${output}
+            DESTINATION ${CMAKE_CURRENT_BINARY_DIR}
+            FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE
+    )
+    file(REMOVE_RECURSE ${CMAKE_CURRENT_BINARY_DIR}/tmp)
+endmacro()
+
+function(configure_script input output)
+    set(CGFORMAT_TEST_DIR ${CMAKE_CURRENT_SOURCE_DIR}/input)
+    set(CGFORMAT_EXE ${CMAKE_CURRENT_BINARY_DIR}/../cgformat)
+    set(CGFORMAT_TESTER_EXE ${CMAKE_CURRENT_BINARY_DIR}/cgformat_tester)
+
+    # To get execute permission: create run.sh in the binary dir, and copy it to scripts folder with permission
+    make_executable(${input} ${output})
+endfunction()
+
+
+configure_script(run_cgformat_tests.sh.in run_cgformat_tests.sh)
+
+

--- a/tools/cgformat/test/input/test_01.v2.gtmcg
+++ b/tools/cgformat/test/input/test_01.v2.gtmcg
@@ -1,0 +1,68 @@
+{
+    "_CG": {
+        "bar": {
+            "callees": [
+                "baz"
+            ],
+            "callers": [
+                "foo"
+            ],
+            "doesOverride": false,
+            "hasBody": true,
+            "isVirtual": false,
+            "meta": {
+                "fileProperties": {
+                    "origin": "/opt/metacg/mcg-local/cgformat_test_01_input.c",
+                    "systemInclude": false
+                },
+                "numStatements": 1
+            },
+            "overriddenBy": [],
+            "overrides": []
+        },
+        "baz": {
+            "callees": [],
+            "callers": [
+                "bar"
+            ],
+            "doesOverride": false,
+            "hasBody": false,
+            "isVirtual": false,
+            "meta": {
+                "fileProperties": {
+                    "origin": "/opt/metacg/mcg-local/cgformat_test_01_input.c",
+                    "systemInclude": false
+                },
+                "numStatements": 0
+            },
+            "overriddenBy": [],
+            "overrides": []
+        },
+        "foo": {
+            "callees": [
+                "bar"
+            ],
+            "callers": [],
+            "doesOverride": false,
+            "hasBody": true,
+            "isVirtual": false,
+            "meta": {
+                "fileProperties": {
+                    "origin": "/opt/metacg/mcg-local/cgformat_test_01_input.c",
+                    "systemInclude": false
+                },
+                "numStatements": 1
+            },
+            "overriddenBy": [],
+            "overrides": []
+        }
+    },
+    "_MetaCG": {
+        "generator": {
+            "name": "CGCollector",
+            "sha": "d28254fde4e10e5682c097563d425bff04142510",
+            "version": "0.9"
+        },
+        "version": "2.0"
+    }
+}

--- a/tools/cgformat/test/input/test_01.v2.unknown_md.mcg
+++ b/tools/cgformat/test/input/test_01.v2.unknown_md.mcg
@@ -1,0 +1,69 @@
+{
+    "_CG": {
+        "bar": {
+            "callees": [
+                "baz"
+            ],
+            "callers": [
+                "foo"
+            ],
+            "doesOverride": false,
+            "hasBody": true,
+            "isVirtual": false,
+            "meta": {
+                "fileProperties": {
+                    "origin": "/opt/metacg/mcg-local/cgformat_test_01_input.c",
+                    "systemInclude": false
+                },
+                "numStatements": 1,
+                "unknown": "???"
+            },
+            "overriddenBy": [],
+            "overrides": []
+        },
+        "baz": {
+            "callees": [],
+            "callers": [
+                "bar"
+            ],
+            "doesOverride": false,
+            "hasBody": false,
+            "isVirtual": false,
+            "meta": {
+                "fileProperties": {
+                    "origin": "/opt/metacg/mcg-local/cgformat_test_01_input.c",
+                    "systemInclude": false
+                },
+                "numStatements": 0
+            },
+            "overriddenBy": [],
+            "overrides": []
+        },
+        "foo": {
+            "callees": [
+                "bar"
+            ],
+            "callers": [],
+            "doesOverride": false,
+            "hasBody": true,
+            "isVirtual": false,
+            "meta": {
+                "fileProperties": {
+                    "origin": "/opt/metacg/mcg-local/cgformat_test_01_input.c",
+                    "systemInclude": false
+                },
+                "numStatements": 1
+            },
+            "overriddenBy": [],
+            "overrides": []
+        }
+    },
+    "_MetaCG": {
+        "generator": {
+            "name": "CGCollector",
+            "sha": "d28254fde4e10e5682c097563d425bff04142510",
+            "version": "0.9"
+        },
+        "version": "2.0"
+    }
+}

--- a/tools/cgformat/test/input/test_01.v2.wrong_origin.mcg
+++ b/tools/cgformat/test/input/test_01.v2.wrong_origin.mcg
@@ -1,0 +1,68 @@
+{
+    "_CG": {
+        "bar": {
+            "callees": [
+                "baz"
+            ],
+            "callers": [
+                "foo"
+            ],
+            "doesOverride": false,
+            "hasBody": true,
+            "isVirtual": false,
+            "meta": {
+                "fileProperties": {
+                    "origin": "/wrong/path/cgformat_test_01_input.c",
+                    "systemInclude": false
+                },
+                "numStatements": 1
+            },
+            "overriddenBy": [],
+            "overrides": []
+        },
+        "baz": {
+            "callees": [],
+            "callers": [
+                "bar"
+            ],
+            "doesOverride": false,
+            "hasBody": false,
+            "isVirtual": false,
+            "meta": {
+                "fileProperties": {
+                    "origin": "/wrong/path/cgformat_test_01_input.c",
+                    "systemInclude": false
+                },
+                "numStatements": 0
+            },
+            "overriddenBy": [],
+            "overrides": []
+        },
+        "foo": {
+            "callees": [
+                "bar"
+            ],
+            "callers": [],
+            "doesOverride": false,
+            "hasBody": true,
+            "isVirtual": false,
+            "meta": {
+                "fileProperties": {
+                    "origin": "/wrong/path/cgformat_test_01_input.c",
+                    "systemInclude": false
+                },
+                "numStatements": 1
+            },
+            "overriddenBy": [],
+            "overrides": []
+        }
+    },
+    "_MetaCG": {
+        "generator": {
+            "name": "CGCollector",
+            "sha": "d28254fde4e10e5682c097563d425bff04142510",
+            "version": "0.9"
+        },
+        "version": "2.0"
+    }
+}

--- a/tools/cgformat/test/input/test_01.v4.gtmcg
+++ b/tools/cgformat/test/input/test_01.v4.gtmcg
@@ -1,0 +1,52 @@
+{
+    "_CG": {
+        "0": {
+            "callees": {
+                "1": {}
+            },
+            "functionName": "bar",
+            "hasBody": true,
+            "meta": {
+                "fileProperties": {
+                    "systemInclude": false
+                },
+                "numStatements": 1
+            },
+            "origin": "/opt/metacg/mcg-local/cgformat_test_01_input.c"
+        },
+        "1": {
+            "callees": {},
+            "functionName": "baz",
+            "hasBody": false,
+            "meta": {
+                "fileProperties": {
+                    "systemInclude": false
+                },
+                "numStatements": 0
+            },
+            "origin": "/opt/metacg/mcg-local/cgformat_test_01_input.c"
+        },
+        "2": {
+            "callees": {
+                "0": {}
+            },
+            "functionName": "foo",
+            "hasBody": true,
+            "meta": {
+                "fileProperties": {
+                    "systemInclude": false
+                },
+                "numStatements": 1
+            },
+            "origin": "/opt/metacg/mcg-local/cgformat_test_01_input.c"
+        }
+    },
+    "_MetaCG": {
+        "generator": {
+            "name": "CGCollector",
+            "sha": "d28254fde4e10e5682c097563d425bff04142510",
+            "version": "0.9"
+        },
+        "version": "4.0"
+    }
+}

--- a/tools/cgformat/test/input/test_01.v4.unknown_md.mcg
+++ b/tools/cgformat/test/input/test_01.v4.unknown_md.mcg
@@ -1,0 +1,53 @@
+{
+    "_CG": {
+        "0": {
+            "callees": {
+                "1": {}
+            },
+            "functionName": "bar",
+            "hasBody": true,
+            "meta": {
+                "fileProperties": {
+                    "systemInclude": false
+                },
+                "numStatements": 1,
+                "unknown": "???"
+            },
+            "origin": "/opt/metacg/mcg-local/cgformat_test_01_input.c"
+        },
+        "1": {
+            "callees": {},
+            "functionName": "baz",
+            "hasBody": false,
+            "meta": {
+                "fileProperties": {
+                    "systemInclude": false
+                },
+                "numStatements": 0
+            },
+            "origin": "/opt/metacg/mcg-local/cgformat_test_01_input.c"
+        },
+        "2": {
+            "callees": {
+                "0": {}
+            },
+            "functionName": "foo",
+            "hasBody": true,
+            "meta": {
+                "fileProperties": {
+                    "systemInclude": false
+                },
+                "numStatements": 1
+            },
+            "origin": "/opt/metacg/mcg-local/cgformat_test_01_input.c"
+        }
+    },
+    "_MetaCG": {
+        "generator": {
+            "name": "CGCollector",
+            "sha": "d28254fde4e10e5682c097563d425bff04142510",
+            "version": "0.9"
+        },
+        "version": "4.0"
+    }
+}

--- a/tools/cgformat/test/input/test_01.v4.wrong_origin.mcg
+++ b/tools/cgformat/test/input/test_01.v4.wrong_origin.mcg
@@ -1,0 +1,52 @@
+{
+    "_CG": {
+        "0": {
+            "callees": {
+                "1": {}
+            },
+            "functionName": "bar",
+            "hasBody": true,
+            "meta": {
+                "fileProperties": {
+                    "systemInclude": false
+                },
+                "numStatements": 1
+            },
+            "origin": "/wrong/path/cgformat_test_01_input.c"
+        },
+        "1": {
+            "callees": {},
+            "functionName": "baz",
+            "hasBody": false,
+            "meta": {
+                "fileProperties": {
+                    "systemInclude": false
+                },
+                "numStatements": 0
+            },
+            "origin": "/wrong/path/cgformat_test_01_input.c"
+        },
+        "2": {
+            "callees": {
+                "0": {}
+            },
+            "functionName": "foo",
+            "hasBody": true,
+            "meta": {
+                "fileProperties": {
+                    "systemInclude": false
+                },
+                "numStatements": 1
+            },
+            "origin": "/wrong/path/cgformat_test_01_input.c"
+        }
+    },
+    "_MetaCG": {
+        "generator": {
+            "name": "CGCollector",
+            "sha": "d28254fde4e10e5682c097563d425bff04142510",
+            "version": "0.9"
+        },
+        "version": "4.0"
+    }
+}

--- a/tools/cgformat/test/run_cgformat_tests.sh.in
+++ b/tools/cgformat/test/run_cgformat_tests.sh.in
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+input_dir="@CGFORMAT_TEST_DIR@"
+cgformat="@CGFORMAT_EXE@"
+cgtester="@CGFORMAT_TESTER_EXE@"
+
+num_failures=0
+
+run_and_expect_success() {
+  "$@"
+  if [[ $? -ne 0 ]]; then
+    echo "Error: Expected success for: $*"
+    ((num_failures++))
+    return 1
+  fi
+  return 0
+}
+
+run_and_expect_failure() {
+  "$@"
+  if [[ $? -eq 0 ]]; then
+    echo "Error: Expected failure for: $*"
+    ((num_failures++))
+    return 1
+  fi
+  return 0
+}
+
+check_and_compare_output() {
+  local gt="$1"
+  local output="$2"
+
+  "$cgtester" "$gt" "$output"
+  if [[ $? -ne 0 ]]; then
+    echo "Error: Output '$output' does not match ground truth '$gt'"
+    ((num_failures++))
+  else
+    rm -f "$output"
+  fi
+}
+
+for gt_input in "$input_dir"/*.gtmcg; do
+  test_path="${gt_input%.gtmcg}"
+  test_name="$(basename "$test_path")"
+
+  echo "Running test case $test_name"
+
+  run_and_expect_success "$cgformat" "$gt_input" --origin_prefix "/opt/metacg/mcg-local"
+
+  # ---- wrong_origin test ----
+  wrong_origin_input="${test_path}.wrong_origin.mcg"
+  if [[ -f "$wrong_origin_input" ]]; then
+    echo "Testing wrong origin"
+
+    run_and_expect_failure "$cgformat" "$wrong_origin_input" --origin_prefix "/opt/metacg/mcg-local"
+
+    echo "Testing fixing wrong origin"
+    output_file="${test_name}.wrong_origin.fixed.mcg"
+    run_and_expect_success "$cgformat" "$wrong_origin_input" \
+      --origin_prefix "/opt/metacg/mcg-local" \
+      --origin_prefix_to_replace "path" \
+      --apply -o "$output_file"
+
+    check_and_compare_output "$gt_input" "$output_file"
+  else
+    echo "No 'wrong_origin' test for $test_name"
+  fi
+
+  # ---- unknown_md test ----
+  unknown_md_input="${test_path}.unknown_md.mcg"
+  if [[ -f "$unknown_md_input" ]]; then
+    echo "Testing catching unknown metadata"
+    output_file="${test_name}.unknown_md.fixed.mcg"
+
+    run_and_expect_failure "$cgformat" "$unknown_md_input" --apply -o "$output_file"
+
+    if [[ -f "$output_file" ]]; then
+      echo "Output file should not have been generated"
+      rm -f "$output_file"
+      ((num_failures++))
+    fi
+
+    run_and_expect_success "$cgformat" "$unknown_md_input" \
+      --discard_failed_metadata --apply -o "$output_file"
+
+    check_and_compare_output "$gt_input" "$output_file"
+  else
+    echo "No 'unknown_md' test for $test_name"
+  fi
+
+done
+
+echo "*******************"
+if (( num_failures )); then
+  echo "Test failures: $num_failures"
+  exit 1
+else
+  echo "All tests succeeded"
+  exit 0
+fi


### PR DESCRIPTION
`cgformat` is a utility tool that enables formatting and checking some properties of MetaCG call graphs.
It has the following features:
- Checking for correct `origin` path prefix
- Re-indentation of the JSON file
- Control over handling of unknown metadata types

This PR includes integration tests that test `cgformat` for correctness on a few typical use cases.

As a follow-up to this PR, I will integrate `cgformat` into the CI to check for wrongly formatted input test files.  