### PR TITLE
Add graph formatting check to CI

### DIFF
--- a/.github/workflows/mcg-ci.yml
+++ b/.github/workflows/mcg-ci.yml
@@ -74,6 +74,11 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           push: false
+      - name: Check for canonical test graph format
+        uses: addnab/docker-run-action@v3
+        with:
+          image: metacg-devel:latest
+          run: /opt/metacg/checkTests.sh  /opt/metacg/build/tools/cgformat/cgformat
       - name: Run MCG library tests 
         uses: addnab/docker-run-action@v3
         with: 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -152,6 +152,12 @@ build-mcg:
     - cmake --build $MCG_BUILD --parallel
     - module purge
 
+check-test-format:
+  <<: *job-setup
+  stage: test
+  needs: ["build-mcg"]
+  script:
+    - ./checkTests.sh $MCG_BUILD/tools/cgformat/cgformat
 
 # Stage: test
 test-cgc:

--- a/cgcollector/test/input/allCtorDtor/0003.gtmcg
+++ b/cgcollector/test/input/allCtorDtor/0003.gtmcg
@@ -18,7 +18,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0003.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0003.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -61,7 +61,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0003.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0003.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -104,7 +104,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0003.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0003.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -156,7 +156,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0003.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0003.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -210,7 +210,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0003.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0003.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,

--- a/cgcollector/test/input/allCtorDtor/0003.noinfer.gtmcg
+++ b/cgcollector/test/input/allCtorDtor/0003.noinfer.gtmcg
@@ -18,7 +18,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/sebastian/git/MetaCG-Gitlab/cgcollector/test/input/allCtorDtor/0003.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0003.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -61,7 +61,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/sebastian/git/MetaCG-Gitlab/cgcollector/test/input/allCtorDtor/0003.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0003.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -104,7 +104,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/sebastian/git/MetaCG-Gitlab/cgcollector/test/input/allCtorDtor/0003.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0003.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -156,7 +156,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/sebastian/git/MetaCG-Gitlab/cgcollector/test/input/allCtorDtor/0003.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0003.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -210,7 +210,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/sebastian/git/MetaCG-Gitlab/cgcollector/test/input/allCtorDtor/0003.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0003.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,

--- a/cgcollector/test/input/allCtorDtor/0004.gtmcg
+++ b/cgcollector/test/input/allCtorDtor/0004.gtmcg
@@ -20,7 +20,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0004.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0004.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -63,7 +63,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0004.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0004.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -106,7 +106,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0004.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0004.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -148,7 +148,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0004.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0004.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -190,7 +190,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0004.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0004.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -235,7 +235,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0004.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0004.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -280,7 +280,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0004.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0004.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,

--- a/cgcollector/test/input/allCtorDtor/0004.noinfer.gtmcg
+++ b/cgcollector/test/input/allCtorDtor/0004.noinfer.gtmcg
@@ -20,7 +20,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0004.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0004.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -60,7 +60,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0004.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0004.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -100,7 +100,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0004.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0004.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -142,7 +142,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0004.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0004.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -184,7 +184,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0004.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0004.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -226,7 +226,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0004.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0004.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -268,7 +268,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0004.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0004.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,

--- a/cgcollector/test/input/allCtorDtor/0005.gtmcg
+++ b/cgcollector/test/input/allCtorDtor/0005.gtmcg
@@ -20,7 +20,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0005.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0005.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -63,7 +63,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0005.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0005.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -106,7 +106,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0005.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0005.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -148,7 +148,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0005.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0005.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -190,7 +190,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0005.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0005.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -235,7 +235,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0005.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0005.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -280,7 +280,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0005.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0005.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,

--- a/cgcollector/test/input/allCtorDtor/0005.noinfer.gtmcg
+++ b/cgcollector/test/input/allCtorDtor/0005.noinfer.gtmcg
@@ -18,7 +18,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0005.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0005.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -58,7 +58,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0005.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0005.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -98,7 +98,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0005.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0005.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -140,7 +140,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0005.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0005.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -182,7 +182,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0005.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0005.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -222,7 +222,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0005.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0005.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -262,7 +262,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0005.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0005.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,

--- a/cgcollector/test/input/allCtorDtor/0006.gtmcg
+++ b/cgcollector/test/input/allCtorDtor/0006.gtmcg
@@ -26,7 +26,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0006.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0006.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -75,7 +75,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0006.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0006.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -118,7 +118,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0006.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0006.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -161,7 +161,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0006.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0006.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -203,7 +203,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0006.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0006.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -245,7 +245,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0006.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0006.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -291,7 +291,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0006.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0006.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -337,7 +337,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0006.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0006.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,

--- a/cgcollector/test/input/allCtorDtor/0006.noinfer.gtmcg
+++ b/cgcollector/test/input/allCtorDtor/0006.noinfer.gtmcg
@@ -26,7 +26,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0006.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0006.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -75,7 +75,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0006.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0006.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -115,7 +115,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0006.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0006.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -155,7 +155,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0006.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0006.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -197,7 +197,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0006.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0006.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -239,7 +239,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0006.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0006.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -282,7 +282,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0006.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0006.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -325,7 +325,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0006.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0006.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,

--- a/cgcollector/test/input/allCtorDtor/0007.gtmcg
+++ b/cgcollector/test/input/allCtorDtor/0007.gtmcg
@@ -20,7 +20,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0007.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0007.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -64,7 +64,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0007.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0007.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -108,7 +108,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0007.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0007.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -150,7 +150,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0007.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0007.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -192,7 +192,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0007.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0007.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -235,7 +235,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0007.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0007.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -278,7 +278,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0007.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0007.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,

--- a/cgcollector/test/input/allCtorDtor/0007.noinfer.gtmcg
+++ b/cgcollector/test/input/allCtorDtor/0007.noinfer.gtmcg
@@ -16,11 +16,10 @@
                     "numVars": 1
                 },
                 "estimateCallCount": {
-                    "calls": {},
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0007.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0007.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -62,7 +61,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0007.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0007.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -104,7 +103,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0007.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0007.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -146,7 +145,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0007.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0007.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -188,7 +187,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0007.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0007.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -228,7 +227,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0007.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0007.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -268,7 +267,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0007.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0007.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,

--- a/cgcollector/test/input/allCtorDtor/0008.gtmcg
+++ b/cgcollector/test/input/allCtorDtor/0008.gtmcg
@@ -20,7 +20,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0008.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0008.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -63,7 +63,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0008.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0008.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -106,7 +106,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0008.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0008.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -148,7 +148,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0008.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0008.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -190,7 +190,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0008.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0008.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -235,7 +235,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0008.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0008.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -280,7 +280,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0008.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0008.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,

--- a/cgcollector/test/input/allCtorDtor/0008.noinfer.gtmcg
+++ b/cgcollector/test/input/allCtorDtor/0008.noinfer.gtmcg
@@ -20,7 +20,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0008.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0008.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -60,7 +60,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0008.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0008.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -100,7 +100,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0008.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0008.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -142,7 +142,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0008.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0008.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -184,7 +184,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0008.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0008.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -226,7 +226,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0008.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0008.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -268,7 +268,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/groups/da_sc/exafoam/metacg_ng/cgcollector/test/input/allCtorDtor/0008.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/allCtorDtor/0008.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,

--- a/cgcollector/test/input/metaCollectors/numStatements/0042.gtmcg
+++ b/cgcollector/test/input/metaCollectors/numStatements/0042.gtmcg
@@ -13,7 +13,7 @@
           "numVars": 5
         },
         "fileProperties": {
-          "origin": "/tmp/tmp.xzlAw8bNoO/cgcollector/test/input/metaCollectors/numStatements/0042.cpp",
+          "origin": "/opt/metacg/mcg-local/cgcollector/test/input/metaCollectors/numStatements/0042.cpp",
           "systemInclude": false
         },
         "globalLoopDepth": 1,
@@ -45,7 +45,7 @@
           "numVars": 4
         },
         "fileProperties": {
-          "origin": "/tmp/tmp.xzlAw8bNoO/cgcollector/test/input/metaCollectors/numStatements/0042.cpp",
+          "origin": "/opt/metacg/mcg-local/cgcollector/test/input/metaCollectors/numStatements/0042.cpp",
           "systemInclude": false
         },
         "globalLoopDepth": 1,

--- a/cgcollector/test/input/singleTU/0215.gtmcg
+++ b/cgcollector/test/input/singleTU/0215.gtmcg
@@ -16,7 +16,7 @@
                     "numVars": 1
                 },
                 "fileProperties": {
-                    "origin": "/home/j_lehr/all_repos/gl-sc-metacg/cgcollector/test/input/singleTU/0215.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/singleTU/0215.cpp",
                     "systemInclude": false
                 },
                 "mallocCollector": [],
@@ -38,7 +38,7 @@
                     "numVars": 0
                 },
                 "fileProperties": {
-                    "origin": "/home/j_lehr/all_repos/gl-sc-metacg/cgcollector/test/input/singleTU/0215.cpp",
+                    "origin": "/opt/metacg/mcg-local/cgcollector/test/input/singleTU/0215.cpp",
                     "systemInclude": false
                 },
                 "mallocCollector": [],

--- a/checkTests.sh
+++ b/checkTests.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 
+# This script goes through all test call graphs and performs basic checks using cgformat.
+
 cgformat="${1:-cgformat}"
+
+if [[ ! -x "$(which $cgformat)" ]]; then
+  echo "Need to pass 'cgformat' executable as argument - exiting."
+  exit 1
+fi
 
 num_failures=0
 
@@ -12,17 +19,28 @@ for dir in "${target_folders[@]}"; do
   full_dir="$script_dir/$dir"
   graph_tests=$(find "$full_dir" -regextype posix-extended -type f -regex '.*\.(gt)?(ipcg|mcg)$')
 
-  echo "$graph_tests"
   echo "Checking ${#graph_tests[@]} MetaCG files in $dir..."
 
   for t in $graph_tests; do
     echo "Checking file: $t"
+
+    # Skipping v1 files
     grep -q '"_MetaCG"' $t
     if [[ $? -ne 0 ]]; then
       echo "File $t has no _MetaCG field - skipping..."
       continue
     fi
+
+    # Skipping null graphs (because otherwise the reader in cgformat fails).
+    grep -q '"_CG": null' $t
+    if [[ $? -eq 0 ]]; then
+      echo "File $t contains 'null' call graph - skipping..."
+      continue
+    fi
+
+    # Invoke cgformat to check for canonical origin prefix
     "$cgformat" --origin_prefix "/opt/metacg" "$t" > /dev/null
+
     if [[ $? -ne 0 ]]; then
       echo "Formatting check failed"
       ((num_failures++))

--- a/checkTests.sh
+++ b/checkTests.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+cgformat="${1:-cgformat}"
+
+num_failures=0
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+target_folders=("graph/test/integration" "pgis/test/integration" "pymetacg/tests/resources" "tools/cgpatch/test/integration/input" "cgcollector/test/input")
+
+for dir in "${target_folders[@]}"; do
+  full_dir="$script_dir/$dir"
+  graph_tests=$(find "$full_dir" -regextype posix-extended -type f -regex '.*\.(gt)?(ipcg|mcg)$')
+
+  echo "$graph_tests"
+  echo "Checking ${#graph_tests[@]} MetaCG files in $dir..."
+
+  for t in $graph_tests; do
+    echo "Checking file: $t"
+    grep -q '"_MetaCG"' $t
+    if [[ $? -ne 0 ]]; then
+      echo "File $t has no _MetaCG field - skipping..."
+      continue
+    fi
+    "$cgformat" --origin_prefix "/opt/metacg" "$t" > /dev/null
+    if [[ $? -ne 0 ]]; then
+      echo "Formatting check failed"
+      ((num_failures++))
+    fi
+  done
+done
+
+echo "Failures: $num_failures"
+
+if ((num_failurs)); then
+  exit 1
+fi

--- a/checkTests.sh
+++ b/checkTests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/env bash
 
 # This script goes through all test call graphs and performs basic checks using cgformat.
 

--- a/tools/cgpatch/test/integration/input/general/01.ipcg
+++ b/tools/cgpatch/test/integration/input/general/01.ipcg
@@ -17,7 +17,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/sm41myca/work/github/MetaCG/tools/cgpatch/test/integration/input/01_a.cpp",
+                    "origin": "/opt/metacg/mcg-local/tools/cgpatch/test/integration/input/01_a.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -61,7 +61,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/sm41myca/work/github/MetaCG/tools/cgpatch/test/integration/input/01_a.cpp",
+                    "origin": "/opt/metacg/mcg-local/tools/cgpatch/test/integration/input/01_a.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -103,7 +103,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/sm41myca/work/github/MetaCG/tools/cgpatch/test/integration/input/01_a.cpp",
+                    "origin": "/opt/metacg/mcg-local/tools/cgpatch/test/integration/input/01_a.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -147,7 +147,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/sm41myca/work/github/MetaCG/tools/cgpatch/test/integration/input/01_a.cpp",
+                    "origin": "/opt/metacg/mcg-local/tools/cgpatch/test/integration/input/01_a.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -205,7 +205,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/sm41myca/work/github/MetaCG/tools/cgpatch/test/integration/input/01_a.cpp",
+                    "origin": "/opt/metacg/mcg-local/tools/cgpatch/test/integration/input/01_a.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -257,7 +257,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "/home/sm41myca/work/github/MetaCG/tools/cgpatch/test/integration/input/01_a.cpp",
+                    "origin": "/opt/metacg/mcg-local/tools/cgpatch/test/integration/input/01_a.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,

--- a/tools/cgpatch/test/integration/input/general/02.ipcg
+++ b/tools/cgpatch/test/integration/input/general/02.ipcg
@@ -1862,7 +1862,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "tools/cgpatch/test/integration/input/02_a.cpp",
+                    "origin": "/opt/metacg/mcg-local/tools/cgpatch/test/integration/input/02_a.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 1,
@@ -1909,7 +1909,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "tools/cgpatch/test/integration/input/02_a.cpp",
+                    "origin": "/opt/metacg/mcg-local/tools/cgpatch/test/integration/input/02_a.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 1,
@@ -1951,7 +1951,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "tools/cgpatch/test/integration/input/02_a.cpp",
+                    "origin": "/opt/metacg/mcg-local/tools/cgpatch/test/integration/input/02_a.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -1993,7 +1993,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "tools/cgpatch/test/integration/input/02_a.cpp",
+                    "origin": "/opt/metacg/mcg-local/tools/cgpatch/test/integration/input/02_a.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -6528,7 +6528,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "tools/cgpatch/test/integration/input/02_a.cpp",
+                    "origin": "/opt/metacg/mcg-local/tools/cgpatch/test/integration/input/02_a.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 1,
@@ -6579,7 +6579,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "tools/cgpatch/test/integration/input/02_a.cpp",
+                    "origin": "/opt/metacg/mcg-local/tools/cgpatch/test/integration/input/02_a.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 1,
@@ -82819,7 +82819,7 @@
                     }
                 },
                 "fileProperties": {
-                    "origin": "tools/cgpatch/test/integration/input/02_a.cpp",
+                    "origin": "/opt/metacg/mcg-local/tools/cgpatch/test/integration/input/02_a.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 2,

--- a/tools/cgpatch/test/integration/input/general/042.ipcg
+++ b/tools/cgpatch/test/integration/input/general/042.ipcg
@@ -13,7 +13,7 @@
                     "numVars": 0
                 },
                 "fileProperties": {
-                    "origin": "042_b.cpp",
+                    "origin": "/opt/metacg/mcg-local/tools/cgpatch/test/input/general/042_b.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -49,7 +49,7 @@
                     "numVars": 1
                 },
                 "fileProperties": {
-                    "origin": "042_b.cpp",
+                    "origin": "/opt/metacg/mcg-local/tools/cgpatch/test/input/general/042_b.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,

--- a/tools/cgpatch/test/integration/input/mpi/001.ipcg
+++ b/tools/cgpatch/test/integration/input/mpi/001.ipcg
@@ -141,7 +141,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "01_a.cpp",
+                    "origin": "/opt/metacg/mcg-local/tools/cgpatch/test/input/mpi/01_a.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -181,7 +181,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "01_a.cpp",
+                    "origin": "/opt/metacg/mcg-local/tools/cgpatch/test/input/mpi/01_a.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,
@@ -244,7 +244,7 @@
                     "codeRegions": {}
                 },
                 "fileProperties": {
-                    "origin": "01_a.cpp",
+                    "origin": "/opt/metacg/mcg-local/tools/cgpatch/test/input/mpi/01_a.cpp",
                     "systemInclude": false
                 },
                 "globalLoopDepth": 0,


### PR DESCRIPTION
This patch adds the `checkTests.sh` script to check all on all test input graphs with `cgformat`. 
This is integrated into the gitlab and github CI pipeline.

All existing test graphs are adjusted to pass these checks.