### PR TITLE
Update to GoogleTest v1.17.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,8 +74,10 @@ endif()
 # Configure the file that holds version information
 configure_file(Config.h.in config.h)
 
-# Provide googletest library
-include(GoogleTest)
+if (METACG_BUILD_UNIT_TESTS)
+  # Provide googletest library
+  include(GoogleTest)
+endif()
 
 # Component options MetaCG graph library will always be built. The actual graph implementation
 add_subdirectory(graph)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ endif()
 # Configure the file that holds version information
 configure_file(Config.h.in config.h)
 
-if (METACG_BUILD_UNIT_TESTS)
+if(METACG_BUILD_UNIT_TESTS)
   # Provide googletest library
   include(GoogleTest)
 endif()

--- a/cmake/GoogleTest.cmake
+++ b/cmake/GoogleTest.cmake
@@ -1,6 +1,6 @@
 include(FetchContent)
 FetchContent_Declare(
-  googletest URL https://github.com/google/googletest/archive/03597a01ee50ed33e9dfd640b249b4be3799d395.zip
+  googletest URL https://github.com/google/googletest/releases/download/v1.17.0/googletest-1.17.0.tar.gz
 )
 FetchContent_MakeAvailable(googletest)
 


### PR DESCRIPTION
Update of GoogleTest, mostly to fix all the warnings with modern CMake versions. Also, GoogleTest is now only downloaded when unit tests are activated in CMake.