### PR TITLE
[NFC] Add common Spack environment paths to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@ tools/cgpatch/test/pass-tests/vcall-detection-test/*.s
 
 
 .idea/
-build*/
+build*
 .cache/
 cmake-build*/
+
+# Spack
+spack.yaml
+spack.lock
+.spack-env/


### PR DESCRIPTION
Ignores paths that come with using a Spack environment to describe the development setup. Additionally, I removed the trailing slash after `build*` to also ignore symlinks to build directories, which is something that can happen when using `spack develop`.