### PR TITLE
[NFC] Mention graph tools and PGIS deprecation in README, document file format update policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,3 +39,11 @@ For example, the commit message may read as
 
 Please use git-clang-format before opening a PR.
 Please follow the naming schemes and capitalization.
+
+## MetaCG file format version
+
+As described in the [graphlib's README](graph/README.md), we distinguish between multiple version of the JSON-based file format for serialized call graphs.
+The file format version numbers are not to be confused with the MetaCG version numbers.
+We consider a file format version to be final as soon as it has been merged into the `master` branch.
+While only on `devel`, a file format version may be subject to breaking changes.
+After being merged to `master`, breaking changes to the file format must be accompanied by a incremented version number.

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ $> cmake --build build --parallel
 $> cmake --install build
 ```
 
-#### Build Graph Library and Tools (CGCollector, PGIS)
+#### Build Graph Library and Tools (CGCollector, PGIS, ...)
 
-You can configure MetaCG to also build CGCollector and PGIS.
+You can configure MetaCG to also build CGCollector, PGIS and other tools based on the graphlib (cgconvert, cgformat, cgmerge2).
 This requires additional dependencies.
 Clang/LLVM (in a supported version) are assumed to be available on the system.
 Extra-P and Cube library can be built using the `build_submodules.sh` script provided in the repository, though the script is not tested outside of our CI system.
@@ -77,7 +77,8 @@ $> cmake -S . -B build \
   -DEXTRAP_INCLUDE="$extinstalldir/extrap/include" \
   -DEXTRAP_LIB="$extinstalldir/extrap/lib" \
   -DMETACG_BUILD_CGCOLLECTOR=ON \
-  -DMETACG_BUILD_PGIS=ON
+  -DMETACG_BUILD_PGIS=ON \
+  -DMETACG_BUILD_GRAPH_TOOLS=ON
 $> cmake --build build --parallel
 # Installation installs CGCollector, CGMerge, CGValidate, PGIS
 $> cmake --install build

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ It uses the JSON file format and separates structure from information, i.e., cal
 The MetaCG graph library is the fundamental component, together with, e.g., I/O facilities.
 The repository also contains an experimental Clang-based tool for call-graph construction at the source-code level.
 As an example tool, the repository contains the PGIS analysis tool, which is used as the analysis backend in [PIRA](https://github.com/tudasc/pira).
+PGIS is currently deprecated and may be removed in a future version.
 
 The current default file format is MetaCG format version 4.
 More info on the different formats can be found in the [graph README](graph/README.md).


### PR DESCRIPTION
This PR contains three changes:
- In the top-level README, it mentions that flag `METACG_BUILD_GRAPH_TOOLS` is required for a full build.
- Mention the PGIS deprecation in README
- Document our policy decision on when we increment file format version numbers