### PR TITLE
[NFC] Always install spdlog, even when using an external json

### DIFF
--- a/cmake/installRules.cmake
+++ b/cmake/installRules.cmake
@@ -86,8 +86,10 @@ install(
 )
 
 # Install public graph library dependencies
+install(TARGETS spdlog EXPORT metacgTargets)
+
 if(NOT METACG_USE_EXTERNAL_JSON)
-  install(TARGETS nlohmann_json spdlog EXPORT metacgTargets)
+  install(TARGETS nlohmann_json EXPORT metacgTargets)
 endif()
 
 # Install the generated CustomMD.h header


### PR DESCRIPTION
MetaCG relies on a static build of spdlog and thus always needs to install the spdlog target so that it can be picked up by projects that use MetaCG.