### PR TITLE
Use fmt::vformat in LoggerUtil to fix problem in new spdlog with C++23

### DIFF
--- a/graph/include/LoggerUtil.h
+++ b/graph/include/LoggerUtil.h
@@ -50,7 +50,7 @@ class MCGLogger {
    */
   template <LogType lt = LogType::DEFAULT, Output outPutType = Output::StdConsole, typename MSG_t, typename... Args>
   void info(const MSG_t msg, Args&&... args) {
-    const std::string& formattedMessage = fmt::format(msg, args...);
+    const std::string& formattedMessage = fmt::vformat(std::string_view(msg), fmt::make_format_args(args...));
     if (ensureUnique<lt>(formattedMessage)) {
       return;
     }
@@ -73,7 +73,7 @@ class MCGLogger {
    */
   template <LogType lt = LogType::DEFAULT, Output outPutType = Output::StdConsole, typename MSG_t, typename... Args>
   void error(const MSG_t msg, Args&&... args) {
-    const std::string& formattedMessage = fmt::format(msg, std::forward<Args>(args)...);
+    const std::string& formattedMessage = fmt::vformat(std::string_view(msg), fmt::make_format_args(args...));
     if (ensureUnique<lt>(formattedMessage)) {
       return;
     }
@@ -96,7 +96,7 @@ class MCGLogger {
    */
   template <LogType lt = LogType::DEFAULT, Output outPutType = Output::StdConsole, typename MSG_t, typename... Args>
   void debug(const MSG_t msg, Args&&... args) {
-    const std::string& formattedMessage = fmt::format(msg, std::forward<Args>(args)...);
+    const std::string& formattedMessage = fmt::vformat(std::string_view(msg), fmt::make_format_args(args...));
     if (ensureUnique<lt>(formattedMessage)) {
       return;
     }
@@ -119,7 +119,7 @@ class MCGLogger {
    */
   template <LogType lt = LogType::DEFAULT, Output outPutType = Output::StdConsole, typename MSG_t, typename... Args>
   void warn(const MSG_t msg, Args&&... args) {
-    const std::string& formattedMessage = fmt::format(msg, std::forward<Args>(args)...);
+    const std::string& formattedMessage = fmt::vformat(std::string_view(msg), fmt::make_format_args(args...));
     if (ensureUnique<lt>(formattedMessage)) {
       return;
     }
@@ -142,7 +142,7 @@ class MCGLogger {
    */
   template <LogType lt = LogType::DEFAULT, Output outPutType = Output::StdConsole, typename MSG_t, typename... Args>
   void critical(const MSG_t msg, Args&&... args) {
-    const std::string& formattedMessage = fmt::format(msg, std::forward<Args>(args)...);
+    const std::string& formattedMessage = fmt::vformat(std::string_view(msg), fmt::make_format_args(args...));
     if (ensureUnique<lt>(formattedMessage)) {
       return;
     }
@@ -165,7 +165,7 @@ class MCGLogger {
    */
   template <LogType lt = LogType::DEFAULT, Output outPutType = Output::StdConsole, typename MSG_t, typename... Args>
   void trace(const MSG_t msg, Args&&... args) {
-    const std::string& formattedMessage = fmt::format(msg, std::forward<Args>(args)...);
+    const std::string& formattedMessage = fmt::vformat(std::string_view(msg), fmt::make_format_args(args...));
     if (ensureUnique<lt>(formattedMessage)) {
       return;
     }

--- a/graph/test/install/main.cpp
+++ b/graph/test/install/main.cpp
@@ -4,10 +4,10 @@
  * https://github.com/tudasc/metacg/LICENSE.txt
  */
 
-#include "Callgraph.h"
 #include "MCGManager.h"
 #include "io/VersionTwoMCGReader.h"
 #include "io/VersionTwoMCGWriter.h"
+#include "LoggerUtil.h"
 
 #include <fstream>
 #include <string>
@@ -15,6 +15,8 @@
 int main(int argc, char** argv) {
   std::string inFile(argv[1]);
   std::string outFile(argv[2]);
+
+  metacg::MCGLogger::logInfo("Testing whether we can log {}!\n", "something");
 
   auto& manager = metacg::graph::MCGManager::get();
   metacg::io::FileSource fSource(inFile);


### PR DESCRIPTION
This PR fixes a problem that occurs with spdlog when enabling C++23 (as is needed for CaPI). Internally, `fmt` then switches to prefering constexpr strings, but offers `fmt::vformat` for dynamic strings. With this PR, we propose to switch to `fmt::vformat` in `LoggerUtil.h`. Also, we add a simple logging statement to `graph/test/install/main.cpp` to test using the logger from a project that uses MetaCG.

Officially, we don't yet support anything other than GCC 11, so the fix is currently untested by our CI. Still, this fix will make our life easier as soon as we start to support GCC >= 13.