### PR TITLE
[NFC] Refactor CGPatch CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,25 +110,6 @@ if(METACG_BUILD_CGCOLLECTOR)
   add_subdirectory(cgcollector)
 endif()
 
-# Build CGPatch: cgpatch-pass, cgpatch-runtime, wrappers, tests
-option(
-  METACG_BUILD_CGPATCH
-  "On or off"
-  OFF
-)
-if(METACG_BUILD_CGPATCH)
-  if(NOT METACG_BUILD_GRAPH_TOOLS)
-    message(FATAL_ERROR "CGPatch requires to build with METACG_BUILD_GRAPH_TOOLS=ON")
-  endif()
-  if(${LLVM_PACKAGE_VERSION}
-     GREATER
-     14
-  )
-    add_subdirectory(tools/cgpatch/)
-  else()
-    message(STATUS "Skipping CGPatch: requires LLVM version 15 or higher")
-  endif()
-endif()
 # PIRA analyzer Should PGIS be built
 option(
   METACG_BUILD_PGIS
@@ -154,18 +135,6 @@ option(
   "On or Off"
   OFF
 )
-
-# Enable MPI for CGPatch
-option(
-  CGPATCH_USE_MPI
-  "On or Off"
-  ON
-)
-
-if(METACG_BUILD_CGPATCH AND CGPATCH_USE_MPI)
-  find_package(MPI REQUIRED)
-  message(STATUS "MPI VERSION: ${MPI_C_VERSION}")
-endif()
 
 # Build MetaCG's Python interface
 option(

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,3 +1,20 @@
+# Build CGPatch: cgpatch-pass, cgpatch-runtime, wrappers, tests
+option(
+  METACG_BUILD_CGPATCH
+  "On or off"
+  OFF
+)
+if(METACG_BUILD_CGPATCH)
+  if(${LLVM_PACKAGE_VERSION}
+     GREATER
+     14
+  )
+    add_subdirectory(cgpatch)
+  else()
+    message(WARNING "Skipping CGPatch: requires LLVM version 15 or higher")
+  endif()
+endif()
+
 add_subdirectory(cgmerge2)
 add_subdirectory(cgconvert)
 add_subdirectory(cgformat)

--- a/tools/cgpatch/CMakeLists.txt
+++ b/tools/cgpatch/CMakeLists.txt
@@ -1,6 +1,16 @@
-project(CGPatch)
-
 include(GNUInstallDirs)
+
+# Enable MPI for CGPatch
+option(
+  CGPATCH_USE_MPI
+  "On or Off"
+  ON
+)
+
+if(CGPATCH_USE_MPI)
+  find_package(MPI REQUIRED)
+  message(STATUS "MPI VERSION: ${MPI_C_VERSION}")
+endif()
 
 # LLVM
 option(


### PR DESCRIPTION
This patch cleans up the CMake options related to CGPatch. 
Changes:
- Move options from main CMakeLists.txt into tools or cgpatch subdirectory
- Remove `project()` declaration in CGPatch CMakeLIsts.txt

