### PR TITLE
[Graph] Fix mergetests target

### DIFF
--- a/graph/test/integration/CallgraphMerge/CMakeLists.txt
+++ b/graph/test/integration/CallgraphMerge/CMakeLists.txt
@@ -10,4 +10,8 @@ target_link_libraries(mergetester PUBLIC metacg::metacg)
 
 add_config_include(mergetester)
 
-add_test(NAME mergeTests COMMAND mergetester)
+add_test(
+  NAME mergeTests
+  COMMAND MergeTestRunner.sh
+  WORKING_DIRECTORY $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+)


### PR DESCRIPTION
The add_test needs to change into the WORKING_DIRECTORY and run the MergeTestRunner.sh script to run the merge tests.