### PR TITLE
Fix bug in Callgraph::erase where edge caches were only partially updated

### DIFF
--- a/graph/src/Callgraph.cpp
+++ b/graph/src/Callgraph.cpp
@@ -9,6 +9,7 @@
 #include "metadata/EntryFunctionMD.h"
 #include "metadata/OverrideMD.h"
 
+#include <algorithm>
 #include <string>
 
 int metacg_RegistryInstanceCounter{0};
@@ -59,10 +60,14 @@ bool Callgraph::erase(NodeId id) {
   // Remove edges
   for (auto& calleeId : calleeList[id]) {
     edges.erase({id, calleeId});
+    auto& childCallerList = callerList.at(calleeId);
+    childCallerList.erase(std::find(childCallerList.begin(), childCallerList.end(), id));
   }
   calleeList.erase(id);
   for (auto& callerId : callerList[id]) {
     edges.erase({callerId, id});
+    auto& parentCalleeList = calleeList.at(callerId);
+    parentCalleeList.erase(std::find(parentCalleeList.begin(), parentCalleeList.end(), id));
   }
   callerList.erase(id);
   // Destroy the node

--- a/graph/test/unit/MCGManagerTest.cpp
+++ b/graph/test/unit/MCGManagerTest.cpp
@@ -131,6 +131,7 @@ TEST_F(MCGManagerTest, EraseNodeWithEdge) {
   int mainNodeId = mainNode.getId();
   int childNodeId = childNode.getId();
   ASSERT_TRUE(cg.addEdge(mainNodeId, childNodeId));
+  ASSERT_EQ(cg.getCallers(childNode).size(), 1);
   ASSERT_TRUE(cg.erase(mainNode.getId()));
   ASSERT_FALSE(cg.hasNode("main"));
   ASSERT_FALSE(cg.hasNode(mainNodeId));
@@ -138,6 +139,7 @@ TEST_F(MCGManagerTest, EraseNodeWithEdge) {
   ASSERT_EQ(cg.getNodeCount(), 1);
   ASSERT_FALSE(cg.isEmpty());
   ASSERT_FALSE(cg.existsEdge(mainNodeId, childNodeId));
+  ASSERT_EQ(cg.getCallers(childNode).size(), 0);
 }
 
 TEST_F(MCGManagerTest, RemoveEdge) {


### PR DESCRIPTION
The caching mechanism is something that we should consider reworking at some point, since it was not designed with node deletion in mind. For now, though, this fix makes sure to update the caller/callee cache also for nodes that are adjacent to the erased node.