### PR TITLE
[CGC2] Fix error in test script

### DIFF
--- a/tools/cgcollector2/test/testBase.sh
+++ b/tools/cgcollector2/test/testBase.sh
@@ -154,8 +154,6 @@ fi
 # Multi-file tests
 multiTests=(0042 0043 0044 0050 0053 0060)
 
-fails=0
-
 echo " --- Running single file tests [file format version 2.0]---"
 echo " --- Running basic tests ---"
 testGlob="./input/singleTU/*.cpp"

--- a/tools/cgcollector2/test/testBase.sh
+++ b/tools/cgcollector2/test/testBase.sh
@@ -240,6 +240,6 @@ for tc in "${multiTests[@]}"; do
 done
 echo "Multi file test failures: $mfails"
 
-tfails=((sfails+mfails))
+tfails=$((sfails+mfails))
 echo -e "$tfails failures occured when running tests"
 exit $tfails

--- a/tools/cgcollector2/test/testBase.sh
+++ b/tools/cgcollector2/test/testBase.sh
@@ -150,6 +150,7 @@ if [[ $? -eq 1 ]]; then
   fi
 fi
 
+sfails=0
 
 # Multi-file tests
 multiTests=(0042 0043 0044 0050 0053 0060)
@@ -161,9 +162,9 @@ for tc in ${testGlob}; do
   echo "Running test ${tc}"
   applyFileFormatTwoToSingleTU ${tc} "--whole-program --NumStatements"
   fail=$?
-  fails=$((fails + fail))
+  sfails=$((sfails + fail))
 done
-echo "Single file test failures: $fails"
+echo "Single file test failures: $sfails"
 
 # Single File and full Ctor/Dtor coverage
 echo -e "\n --- Running single file full ctor/dtor tests ---"
@@ -173,9 +174,9 @@ for tc in ${testGlob}; do
   #we need to capture implicits here, as some calls are to implicit constructors/destructors
   applyFileFormatTwoToSingleTU ${tc} "--capture-ctors-dtors --capture-new-delete-calls --capture-implicits --infer-ctors-dtors --whole-program --prune --NumStatements"
   fail=$?
-  fails=$((fails + fail))
+  sfails=$((sfails + fail))
 done
-echo "Single file test failures: $fails"
+echo "Single file test failures: $sfails"
 
 # Single File and for CXXRecordCalls
 echo -e "\n --- Running single file CXXRecord call tests ---"
@@ -185,9 +186,9 @@ for tc in ${testGlob}; do
   #we need to capture implicits here, as some calls are to implicit constructors/destructors
   applyFileFormatTwoToSingleTU ${tc} "--capture-ctors-dtors --capture-new-delete-calls --capture-implicits --infer-ctors-dtors --whole-program --prune --NumStatements"
   fail=$?
-  fails=$((fails + fail))
+  sfails=$((sfails + fail))
 done
-echo "Single file test failures: $fails"
+echo "Single file test failures: $sfails"
 
 
 # Single File and functionPointers
@@ -197,9 +198,9 @@ for tc in ${testGlob}; do
   echo "Running test ${tc}"
   applyFileFormatTwoToSingleTU ${tc} "--whole-program --NumStatements"
   fail=$?
-  fails=$((fails + fail))
+  sfails=$((sfails + fail))
 done
-echo "Single file test failures: $fails"
+echo "Single file test failures: $sfails"
 
 
 
@@ -210,10 +211,10 @@ for tc in ${testGlob}; do
   echo "Running test ${tc}"
   applyFileFormatTwoToSingleTU ${tc}  "--whole-program --NumStatements"
   fail=$?
-  fails=$((fails + fail))
+  sfails=$((sfails + fail))
 done
 
-echo "Single file test failures: $fails"
+echo "Single file test failures: $sfails"
 
 # Single File virtualCalls
 echo -e "\n --- Running single file virtualCalls tests ---"
@@ -222,22 +223,23 @@ for tc in ${testGlob}; do
   echo "Running test ${tc}"
   applyFileFormatTwoToSingleTU ${tc} "--whole-program --capture-ctors-dtors --NumStatements --OverrideMD"
   fail=$?
-  fails=$((fails + fail))
+  sfails=$((sfails + fail))
 done
-echo "Single file test failures: $fails"
+echo "Single file test failures: $sfails"
 
 
 # Multi File
-fails=0
+mfails=0
 echo -e "\n --- Running multi file tests ---"
 for tc in "${multiTests[@]}"; do
   echo "Running test ${tc}"
   # Input files
   applyFileFormatTwoToMultiTU ${tc} ""
   fail=$?
-  fails=$((fails + fail))
+  mfails=$((mfails + fail))
 done
-echo "Multi file test failures: $fails"
+echo "Multi file test failures: $mfails"
 
-echo -e "$fails failures occured when running tests"
-exit $fails
+tfails=((sfails+mfails))
+echo -e "$tfails failures occured when running tests"
+exit $tfails


### PR DESCRIPTION
This error leads to single-file test errors being ignored as observed in a local run of the tests.