### PR TITLE
[CI] Fix build path for cgc2 testing downstream

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -259,7 +259,7 @@ test-cgcollector2:
   script:
     - module load clang/$LLVM
     - cd tools/cgcollector2/test/
-    - ./testBase.sh
+    - ./testBase.sh -b $MCG_BUILD
 
 test-basic-pgis:
   <<: *job-setup


### PR DESCRIPTION
In the downstream CI the build directory name depends on the different compiler modules that are loaded, hence we need to make it explicit.