### PR TITLE
[NFC] Fix logic to get source file name when using LLVM 21

### DIFF
--- a/tools/cgcollector2/fileInfoDemoPlugin/FileInfoMetadataPlugin.cpp
+++ b/tools/cgcollector2/fileInfoDemoPlugin/FileInfoMetadataPlugin.cpp
@@ -23,7 +23,13 @@ struct FileInfoMetadataPlugin : Plugin {
     const auto sourceLocation = functionDecl->getLocation();
     auto& astCtx = functionDecl->getASTContext();
     const auto fullSrcLoc = astCtx.getFullLoc(sourceLocation);
+
+#if LLVM_VERSION_MAJOR < 21
     const auto fileEntry = fullSrcLoc.getFileEntry();
+#else
+    const auto fileEntry = fullSrcLoc.getFileEntryRef();
+#endif
+    
     if (!fileEntry) {
       return result;
     }


### PR DESCRIPTION
We don't support LLVM 21 yet, but as soon as we do, we will need this. (Also, I need MetaCG with LLVM 21 right now, so that's why there's is a fix.)