### PR TITLE
Allow reading null CG in v2

### DIFF
--- a/graph/src/io/VersionTwoMCGReader.cpp
+++ b/graph/src/io/VersionTwoMCGReader.cpp
@@ -51,6 +51,7 @@ std::unique_ptr<metacg::Callgraph> metacg::io::VersionTwoMCGReader::read() {
 
   MCGFileInfo fileInfo{ffInfo, genVersionInfo};
   if (j.at(ffInfo.cgFieldName).is_null()) {
+    j[ffInfo.cgFieldName] = nlohmann::json::object();
     const std::string warningMsg = "Detected null call graph in metacg file; proceeding with an empty call graph.";
     MCGLogger::logWarn(warningMsg);
   }

--- a/graph/src/io/VersionTwoMCGReader.cpp
+++ b/graph/src/io/VersionTwoMCGReader.cpp
@@ -50,7 +50,12 @@ std::unique_ptr<metacg::Callgraph> metacg::io::VersionTwoMCGReader::read() {
                 generatorVersion);
 
   MCGFileInfo fileInfo{ffInfo, genVersionInfo};
-  if (!j.contains(ffInfo.cgFieldName) || j.at(ffInfo.cgFieldName).is_null()) {
+  if (j.at(ffInfo.cgFieldName).is_null()) {
+    const std::string warningMsg = "Detected null call graph in metacg file; proceeding with an empty call graph.";
+    MCGLogger::logWarn(warningMsg);
+  }
+
+  if (!j.contains(ffInfo.cgFieldName)) {
     const std::string errorMsg = "The call graph in the metacg file was not found or null.";
     errConsole->error(errorMsg);
     throw std::runtime_error(errorMsg);

--- a/graph/test/unit/VersionTwoMCGReaderTest.cpp
+++ b/graph/test/unit/VersionTwoMCGReaderTest.cpp
@@ -66,7 +66,7 @@ class TestMetaData : public metacg::MetaData::Registrar<TestMetaData> {
   float metadataFloat = 0.0f;
 };
 
-TEST_F(V2MCGReaderTest, NullCG) {
+TEST_F(V2MCGReaderTest, NoCG) {
   nlohmann::json j;
   auto& mcgm = metacg::graph::MCGManager::get();
   metacg::io::JsonSource jsonSource(j);
@@ -122,7 +122,7 @@ TEST_F(V2MCGReaderTest, WrongVersionInformation) {
   }
 }
 
-TEST_F(V2MCGReaderTest, BrokenCG) {
+TEST_F(V2MCGReaderTest, NullCG) {
   nlohmann::json j =
       "{\n"
       "         \"_CG\": null,\n"
@@ -141,9 +141,8 @@ TEST_F(V2MCGReaderTest, BrokenCG) {
   auto& mcgm = metacg::graph::MCGManager::get();
   try {
     mcgReader.read();
-    EXPECT_TRUE(false);  // should not reach here
   } catch (std::exception& e) {
-    EXPECT_TRUE(strcmp(e.what(), "The call graph in the metacg file was not found or null.") == 0);
+    EXPECT_TRUE(false);  // should not reach here
   }
 }
 


### PR DESCRIPTION
This patch enables reading call graphs with `CG: null` entry .