### PR TITLE
[CMake] Add cache files for convenience

### DIFF
--- a/.github/workflows/mcg-ci.yml
+++ b/.github/workflows/mcg-ci.yml
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: cmake
         run: cmake -B build -S . -C cmake/caches/GraphTools.cmake
       - name: build

--- a/.github/workflows/mcg-ci.yml
+++ b/.github/workflows/mcg-ci.yml
@@ -64,7 +64,18 @@ jobs:
         stat $MCG_CFG
         [[ "$($MCG_CFG --prefix)" == "$(cd install; pwd)" ]] || exit 1
         [[ "$($MCG_CFG --revision)" == "$(git rev-parse HEAD)" ]] || exit 1
-  
+
+  # Make sure the cache file builds
+  graph-tools-cache-build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: cmake
+        run: cmake -B build -S . -C cmake/caches/GraphTools.cmake
+      - name: build
+        run: cmake --build build --parallel
+
   build-container:
     runs-on: ubuntu-latest
     steps:

--- a/cmake/caches/FullBuild.cmake
+++ b/cmake/caches/FullBuild.cmake
@@ -1,0 +1,12 @@
+# This is a CMake cache file for a full build
+set(CMAKE_BUILD_TYPE Release CACHE STRING "")
+
+# Get external dependencies
+set(CUBE_DIR "extern/install/cubelib" CACHE STRING "")
+set(EXTRAP_INCLUDE "extern/install/extrap/include" CACHE STRING "")
+set(EXTRAP_LIB "extern/install/extrap/lib" CACHE STRING "")
+
+# Enable all features from MetaCG
+set(METACG_BUILD_CGCOLLECTOR ON CACHE BOOL "")
+set(METACG_BUILD_PGIS ON CACHE BOOL "")
+set(METACG_BUILD_GRAPH_TOOLS ON CACHE BOOL "")

--- a/cmake/caches/FullBuild.cmake
+++ b/cmake/caches/FullBuild.cmake
@@ -1,12 +1,33 @@
 # This is a CMake cache file for a full build
-set(CMAKE_BUILD_TYPE Release CACHE STRING "")
+set(CMAKE_BUILD_TYPE
+    Release
+    CACHE STRING ""
+)
 
 # Get external dependencies
-set(CUBE_DIR "extern/install/cubelib" CACHE STRING "")
-set(EXTRAP_INCLUDE "extern/install/extrap/include" CACHE STRING "")
-set(EXTRAP_LIB "extern/install/extrap/lib" CACHE STRING "")
+set(CUBE_DIR
+    "extern/install/cubelib"
+    CACHE STRING ""
+)
+set(EXTRAP_INCLUDE
+    "extern/install/extrap/include"
+    CACHE STRING ""
+)
+set(EXTRAP_LIB
+    "extern/install/extrap/lib"
+    CACHE STRING ""
+)
 
 # Enable all features from MetaCG
-set(METACG_BUILD_CGCOLLECTOR ON CACHE BOOL "")
-set(METACG_BUILD_PGIS ON CACHE BOOL "")
-set(METACG_BUILD_GRAPH_TOOLS ON CACHE BOOL "")
+set(METACG_BUILD_CGCOLLECTOR
+    ON
+    CACHE BOOL ""
+)
+set(METACG_BUILD_PGIS
+    ON
+    CACHE BOOL ""
+)
+set(METACG_BUILD_GRAPH_TOOLS
+    ON
+    CACHE BOOL ""
+)

--- a/cmake/caches/GraphTools.cmake
+++ b/cmake/caches/GraphTools.cmake
@@ -1,0 +1,7 @@
+# This is a CMake cache file for a full build
+set(CMAKE_BUILD_TYPE Release CACHE STRING "")
+
+# Enable all features from MetaCG
+set(METACG_BUILD_CGCOLLECTOR OFF CACHE BOOL "")
+set(METACG_BUILD_PGIS OFF CACHE BOOL "")
+set(METACG_BUILD_GRAPH_TOOLS ON CACHE BOOL "")

--- a/cmake/caches/GraphTools.cmake
+++ b/cmake/caches/GraphTools.cmake
@@ -1,7 +1,19 @@
 # This is a CMake cache file for a full build
-set(CMAKE_BUILD_TYPE Release CACHE STRING "")
+set(CMAKE_BUILD_TYPE
+    Release
+    CACHE STRING ""
+)
 
 # Enable all features from MetaCG
-set(METACG_BUILD_CGCOLLECTOR OFF CACHE BOOL "")
-set(METACG_BUILD_PGIS OFF CACHE BOOL "")
-set(METACG_BUILD_GRAPH_TOOLS ON CACHE BOOL "")
+set(METACG_BUILD_CGCOLLECTOR
+    OFF
+    CACHE BOOL ""
+)
+set(METACG_BUILD_PGIS
+    OFF
+    CACHE BOOL ""
+)
+set(METACG_BUILD_GRAPH_TOOLS
+    ON
+    CACHE BOOL ""
+)


### PR DESCRIPTION
Adding two CMake cache files to make building MetaCG more convenient.

One cache is a full build that requires the external dependencies to be installed via the build_submodules.sh script.

The other cache is a build of the "new" graph tools that does not depend on the external components.