### PR TITLE
[CGDiff] Fix CMake to build tests only when METACG_BUILD_UNIT_TESTS is enabled

### DIFF
--- a/tools/cgdiff/CMakeLists.txt
+++ b/tools/cgdiff/CMakeLists.txt
@@ -5,4 +5,6 @@ target_include_directories(cgdiff PRIVATE include)
 add_metacg(cgdiff)
 add_cxxopts(cgdiff)
 
-add_subdirectory(test/unit)
+if(METACG_BUILD_UNIT_TESTS)
+  add_subdirectory(test/unit)
+endif()


### PR DESCRIPTION
Fixes CMake error when building without `METACG_BUILD_UNIT_TESTS`:

```
     52    
     53    -- LOG_LEVEL=INFO
  >> 54    CMake Error at tools/cgdiff/test/unit/CMakeLists.txt:12 (add_googletest_libraries):
     55      Unknown CMake command "add_googletest_libraries".
     56    
```

CC @silas-martens 