### PR TITLE
Fix Clang version check for FileEntry::getName()

### DIFF
--- a/tools/cgcollector2/fileInfoDemoPlugin/FileInfoMetadataPlugin.cpp
+++ b/tools/cgcollector2/fileInfoDemoPlugin/FileInfoMetadataPlugin.cpp
@@ -24,7 +24,7 @@ struct FileInfoMetadataPlugin : Plugin {
     auto& astCtx = functionDecl->getASTContext();
     const auto fullSrcLoc = astCtx.getFullLoc(sourceLocation);
 
-#if LLVM_VERSION_MAJOR < 19
+#if LLVM_VERSION_MAJOR < 18
     const auto fileEntry = fullSrcLoc.getFileEntry();
 #else
     const auto fileEntry = fullSrcLoc.getFileEntryRef();

--- a/tools/cgcollector2/fileInfoDemoPlugin/FileInfoMetadataPlugin.cpp
+++ b/tools/cgcollector2/fileInfoDemoPlugin/FileInfoMetadataPlugin.cpp
@@ -24,7 +24,7 @@ struct FileInfoMetadataPlugin : Plugin {
     auto& astCtx = functionDecl->getASTContext();
     const auto fullSrcLoc = astCtx.getFullLoc(sourceLocation);
 
-#if LLVM_VERSION_MAJOR < 21
+#if LLVM_VERSION_MAJOR < 19
     const auto fileEntry = fullSrcLoc.getFileEntry();
 #else
     const auto fileEntry = fullSrcLoc.getFileEntryRef();


### PR DESCRIPTION
`FileEntry::getName()` was deprecated in clang 18 and removed in clang 19 (https://github.com/llvm/llvm-project/commit/6c1dbd5359c4336d03b11faeaea8459b421f2c5c).


This fixes compilation with Clang 20 on my local machine.