### PR TITLE
Pretty print JSON output of cgdiff

### DIFF
--- a/tools/cgdiff/CGDiff.cpp
+++ b/tools/cgdiff/CGDiff.cpp
@@ -237,7 +237,7 @@ int main(int argc, char** argv) {
 
       *out << DiffFormatter::emitAsJson(diffs, ignoring, std::filesystem::absolute(cg1).string(),
                                         std::filesystem::absolute(cg2).string())
-                  .dump();
+                  .dump(2);
     }
 
     if (diffs.empty()) {


### PR DESCRIPTION
Minor change to pretty print the JSON output of `cgdiff`, making it much easier to read.