### PR TITLE
Add install rules for cgdiff and cgquery

### DIFF
--- a/.github/workflows/mcg-ci.yml
+++ b/.github/workflows/mcg-ci.yml
@@ -80,6 +80,19 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           push: false
+      - name: Install tests
+        uses: maus007/docker-run-action-fork@207a4e2a8ebf7e4b985656ba990b1e53715dce2a
+        with:
+          image: metacg-devel:latest
+          run: |
+            stat /tmp/metacg/lib/libmetacg.so
+            stat /tmp/metacg/include/metadata/CustomMD.h
+            stat /tmp/metacg/lib/cmake/metacg/metacgConfig.cmake
+            stat /tmp/metacg/bin/metacg-config
+            stat /tmp/metacg/bin/cgdiff
+            stat /tmp/metacg/bin/cgquery
+            stat /tmp/metacg/bin/cgformat
+            stat /tmp/metacg/bin/cgconvert
       - name: Check for canonical test graph format
         uses: maus007/docker-run-action-fork@207a4e2a8ebf7e4b985656ba990b1e53715dce2a
         with:

--- a/tools/cgdiff/CMakeLists.txt
+++ b/tools/cgdiff/CMakeLists.txt
@@ -1,3 +1,6 @@
+set(PROJECT_NAME CGDiff)
+set(TARGETS_EXPORT_NAME ${PROJECT_NAME}-target)
+
 add_executable(cgdiff CGDiff.cpp)
 
 target_include_directories(cgdiff PRIVATE include)
@@ -8,3 +11,16 @@ add_cxxopts(cgdiff)
 if(METACG_BUILD_UNIT_TESTS)
   add_subdirectory(test/unit)
 endif()
+
+install(
+  TARGETS cgdiff
+  EXPORT ${TARGETS_EXPORT_NAME}
+  RUNTIME DESTINATION bin
+)
+
+configure_package_config_file(
+  ${METACG_Directory}/cmake/Config.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+  INSTALL_DESTINATION lib/cmake
+)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake DESTINATION lib/cmake)

--- a/tools/cgquery/CMakeLists.txt
+++ b/tools/cgquery/CMakeLists.txt
@@ -1,4 +1,20 @@
+set(PROJECT_NAME CGQuery)
+set(TARGETS_EXPORT_NAME ${PROJECT_NAME}-target)
+
 add_executable(cgquery CGQuery.cpp)
 
 add_metacg(cgquery)
 add_cxxopts(cgquery)
+
+install(
+  TARGETS cgquery
+  EXPORT ${TARGETS_EXPORT_NAME}
+  RUNTIME DESTINATION bin
+)
+
+configure_package_config_file(
+  ${METACG_Directory}/cmake/Config.cmake.in ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
+  INSTALL_DESTINATION lib/cmake
+)
+
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake DESTINATION lib/cmake)


### PR DESCRIPTION
This PR adds the missing install rules for cgdiff and cgquery. cgpatch already seems to have working install rules.

Closes #113 