### PR TITLE
[Cage] Only pass non-resolved calls to metavirt

### DIFF
--- a/tools/cage/src/generator/CallGraphGenerator.cpp
+++ b/tools/cage/src/generator/CallGraphGenerator.cpp
@@ -58,7 +58,8 @@ struct CallBaseVisitor : public llvm::InstVisitor<CallBaseVisitor> {
   ~CallBaseVisitor() = default;
 
   void visitCallBase(llvm::CallBase& I) {
-    if (I.getCalledFunction() != nullptr && I.getCalledFunction()->isIntrinsic())
+    // only pass non-resolved calls to metavirt
+    if (I.getCalledFunction() != nullptr)
       return;
     auto* currentFunction = I.getParent()->getParent();
     auto& currentNode = mcg->getSingleNode(currentFunction->getName().str());
@@ -69,15 +70,14 @@ struct CallBaseVisitor : public llvm::InstVisitor<CallBaseVisitor> {
         return;
     }
 
-    if (I.getCalledFunction() == nullptr) {
-      // Was function pointer, where we can not get the called function
-      if (pta == PTAType::BySignature) {
-        const auto& possibleFuncs = signatureFunctionMap[I.getFunctionType()];
-        for (const auto& func : possibleFuncs) {
-          assert(func);
-          auto& childNode = getOrInsertNode(func);
-          insertEdge(currentNode, childNode);
-        }
+    // metavirt turned up with nothing
+    // --> was function pointer, where we can not get the called function
+    if (pta == PTAType::BySignature) {
+      const auto& possibleFuncs = signatureFunctionMap[I.getFunctionType()];
+      for (const auto& func : possibleFuncs) {
+        assert(func);
+        auto& childNode = getOrInsertNode(func);
+        insertEdge(currentNode, childNode);
       }
     }
   }


### PR DESCRIPTION
Currently, Cage passes all calls to metavirt, even those that can be resolved just with `getCalledFunction`, leading to crashes in metavirt as it is only designed to handle virtual calls. With this PR, we only call metavirt for calls that can't be easily resolved.