### PR TITLE
[MetaCG] Add LLVM-20 container recipe

### DIFF
--- a/.github/workflows/mcg-ci.yml
+++ b/.github/workflows/mcg-ci.yml
@@ -64,6 +64,42 @@ jobs:
         stat $MCG_CFG
         [[ "$($MCG_CFG --prefix)" == "$(cd install; pwd)" ]] || exit 1
         [[ "$($MCG_CFG --revision)" == "$(git rev-parse HEAD)" ]] || exit 1
+
+  # TODO: Complete the llvm-20 based CI definition
+  build-container-llvm-20:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: "container/full-build-llvm-20"
+          tags: metacg-llvm-20-devel:latest
+          load: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: false
+      - name: Install tests
+        uses: maus007/docker-run-action-fork@207a4e2a8ebf7e4b985656ba990b1e53715dce2a
+        with:
+          image: metacg-llvm-20-devel:latest
+          run: |
+            stat /tmp/metacg/lib/libmetacg.so
+            stat /tmp/metacg/include/metadata/CustomMD.h
+            stat /tmp/metacg/lib/cmake/metacg/metacgConfig.cmake
+            stat /tmp/metacg/bin/metacg-config
+            stat /tmp/metacg/bin/cgdiff
+            stat /tmp/metacg/bin/cgquery
+            stat /tmp/metacg/bin/cgformat
+            stat /tmp/metacg/bin/cgconvert
+            stat /tmp/metacg/bin/cgtodot
+      - name: Check for canonical test graph format
+        uses: maus007/docker-run-action-fork@207a4e2a8ebf7e4b985656ba990b1e53715dce2a
+        with:
+          image: metacg-llvm-20-devel:latest
+          run: /opt/metacg/checkTests.sh  /opt/metacg/build/tools/cgformat/cgformat
   
   build-container:
     runs-on: ubuntu-latest

--- a/container/full-build-llvm-20
+++ b/container/full-build-llvm-20
@@ -1,0 +1,62 @@
+FROM debian:bookworm-slim
+
+WORKDIR /opt/metacg
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -y && \
+    apt-get upgrade -y && \
+    apt-get install -y gcc g++ gdb \
+        cmake python3 apt-utils wget gnupg \
+        qtbase5-dev git autoconf automake \
+        libtool zlib1g-dev zlib1g vim unzip \
+        python3-pip python3-venv \
+        openmpi-bin openmpi-common bison flex bear \
+        lsb-release wget software-properties-common \
+        python3-matplotlib python3-pyqt5 ninja-build \
+    libopenmpi-dev libhwloc-dev libevent-dev \
+    jq
+
+RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc && \
+    add-apt-repository -y 'deb http://apt.llvm.org/bookworm/  llvm-toolchain-bookworm-20 main' && \
+    add-apt-repository -y 'deb http://apt.llvm.org/bookworm/  llvm-toolchain-bookworm-20 main' && \
+    apt-get update && \
+    apt-get install -y libllvm20 llvm-20 llvm-20-dev llvm-20-runtime \
+        clang-20 clang-tools-20 libclang-common-20-dev libclang-20-dev libclang1-20 \
+    lld-20 libmlir-20-dev mlir-20-tools flang-20
+RUN bash -c "ln -s $(which clang-20) /usr/bin/clang" && \
+    bash -c "ln -s $(which clang++-20) /usr/bin/clang++" && \
+    bash -c "ln -s $(which llvm-config-20) /usr/bin/llvm-config" && \
+    bash -c "ln -s $(flang-new-20) /usr/bin/flang-new"
+
+ARG extinstalldir=/opt/metacg/extern/install
+ENV EXTINSTALLDIR=$extinstalldir
+
+COPY ./build_submodules.sh /opt/metacg
+
+RUN ./build_submodules.sh $(nproc)
+
+COPY . /opt/metacg
+
+RUN cmake -S . -B build -GNinja -DCMAKE_BUILD_TYPE=Debug \
+      -DCMAKE_INSTALL_PREFIX=/tmp/metacg \
+      -DCUBE_DIR=$EXTINSTALLDIR/cubelib \
+      -DEXTRAP_INCLUDE=$EXTINSTALLDIR/extrap/include \
+      -DEXTRAP_LIB=$EXTINSTALLDIR/extrap/lib \
+      -DMETACG_BUILD_PGIS=ON \
+      -DMETACG_BUILD_CGCOLLECTOR=ON \
+      -DMETACG_BUILD_GRAPH_TOOLS=ON \
+      -DMETACG_BUILD_CGPATCH=ON \
+      -DMETACG_BUILD_GRAPH_TOOLS=ON \
+      -DCAGE_USE_METAVIRT=ON \
+      -DMETACG_BUILD_PYMETACG=ON \
+      -DPython_ROOT_DIR=/opt/metacg/.venv \
+      -DPYTEST_EXECUTABLE=/opt/metacg/.venv/bin/pytest \
+      -DCMAKE_MODULE_PATH=/opt/metacg/.venv/share/Pytest/cmake \
+      -DMETACG_BUILD_PYMETACG_TESTS=ON \
+      -DCMAKE_VERBOSE_MAKEFILE=ON \
+      -DLLVM_EXTERNAL_LIT=/usr/lib/llvm-20/build/utils/lit/lit.py 
+
+RUN cmake --build build --parallel
+
+RUN cmake --install build


### PR DESCRIPTION
In preparation to add an LLVM-20 based build of MetaCG to our upstream GH actions testing, provide a container recipe that can be used in that action.