### PR TITLE
[CI] Only cmake-format changed files in workflow

### DIFF
--- a/.github/workflows/mcg-lint.yml
+++ b/.github/workflows/mcg-lint.yml
@@ -40,7 +40,7 @@ jobs:
           for f in ${CHANGED_FILES}; do 
             if [[ $f == *.cmake ]]; then 
               cmake-format --check $f 
-            elif [[ $f == "CMakeLists.txt" ]]; then 
+            elif [[ $f == "*CMakeLists.txt" ]]; then 
               cmake-format --check $f 
             fi
           done

--- a/.github/workflows/mcg-lint.yml
+++ b/.github/workflows/mcg-lint.yml
@@ -14,7 +14,33 @@ jobs:
         run: |
           python3 -m pip install cmakelang
       - uses: actions/checkout@v4
-      - name: CMake Lint
+        with:
+          fetch-depth: 2
+
+      - name: Changed Files 
+        id: changed-files
+        uses: tj-actions/changed-files@e0021407031f5be11a464abee9a0776171c79891 # v47.0.1
+        with: 
+          separator: " "
+          skip_initial_fetch: true
+          base_sha: 'HEAD~1'
+          sha: 'HEAD'
+      
+      - name: List changed files 
+        env: 
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
-          for f in $(find {cgcollector,graph,pgis,tools,pymetacg} -name "CMakeLists.txt"); do cmake-format --check $f || exit 1; done ; cmake-format --check CMakeLists.txt
-          for f in $(find ./cmake -type f); do cmake-format --check $f || exit 1; done
+          echo "Changed files:"
+          echo "${CHANGED_FILES}"
+
+      - name: CMake Lint
+        env:
+          CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          for f in ${CHANGED_FILES}; do 
+            if [[ $f == *.cmake ]]; then 
+              cmake-format --check $f 
+            elif [[ $f == "CMakeLists.txt" ]]; then 
+              cmake-format --check $f 
+            fi
+          done

--- a/.github/workflows/mcg-lint.yml
+++ b/.github/workflows/mcg-lint.yml
@@ -38,9 +38,11 @@ jobs:
           CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           for f in ${CHANGED_FILES}; do 
-            if [[ $f == *.cmake ]]; then 
+            echo "Running on $f"
+            filename=$(basename $f)
+            if [[ $filename == *.cmake ]]; then 
               cmake-format --check $f 
-            elif [[ $f == "*CMakeLists.txt" ]]; then 
+            elif [[ $filename == "CMakeLists.txt" ]]; then 
               cmake-format --check $f 
             fi
           done

--- a/pymetacg/CMakeLists.txt
+++ b/pymetacg/CMakeLists.txt
@@ -18,7 +18,7 @@ nanobind_disable_stack_protector(pymetacg)
 add_metacg_library(pymetacg)
 
 if(NOT CMAKE_INSTALL_PYTHON_LIBDIR)
-  set(CMAKE_INSTALL_PYTHON_LIBDIR
+set(CMAKE_INSTALL_PYTHON_LIBDIR
       "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages"
   )
 endif()

--- a/pymetacg/CMakeLists.txt
+++ b/pymetacg/CMakeLists.txt
@@ -18,7 +18,7 @@ nanobind_disable_stack_protector(pymetacg)
 add_metacg_library(pymetacg)
 
 if(NOT CMAKE_INSTALL_PYTHON_LIBDIR)
-set(CMAKE_INSTALL_PYTHON_LIBDIR
+  set(CMAKE_INSTALL_PYTHON_LIBDIR
       "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages"
   )
 endif()


### PR DESCRIPTION
Previously the CMake lint step always looked at all CMake files across various places.
This PR changes that behavior to always look at CMake files that are touched by a PR.