### PR TITLE
[MetaCG] Update version to 1.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 # End of require out-of-source builds
 
 # Project information
-set(METACG_VERSION 0.9.0)
+set(METACG_VERSION 1.0.0)
 project(
   MetaCG
   VERSION ${METACG_VERSION}


### PR DESCRIPTION
In preparation of the next release, bump the version number to 1.0.0 We deemed many features of MetaCG to be good enough and reasonably stable.