### PR TITLE
Refactor cgc2's plugin interface to use LLVM's utilities

### DIFF
--- a/tools/cgcollector2/src/Plugin.cpp
+++ b/tools/cgcollector2/src/Plugin.cpp
@@ -7,23 +7,25 @@
 #include "Plugin.h"
 #include "LoggerUtil.h"
 
-#include <dlfcn.h>
+#include "llvm/Support/DynamicLibrary.h"
 
 Plugin* loadPlugin(const std::string& pluginPath) {
   metacg::MCGLogger::instance().getConsole()->debug("Loading plugin");
-  void* handle = dlopen(pluginPath.c_str(), 1);
-  if (!handle) {
+  std::string err;
+  auto lib = llvm::sys::DynamicLibrary::getPermanentLibrary(pluginPath.c_str(), &err);
+  if (!lib.isValid()) {
     metacg::MCGLogger::instance().getErrConsole()->error("cannot locate the library at {}!", pluginPath);
+    metacg::MCGLogger::instance().getErrConsole()->error("Reason: {}", err);
     return nullptr;
   }
   metacg::MCGLogger::instance().getConsole()->trace("Getting collection object from plugin {}", pluginPath);
-  auto (*getPlugin)() = (Plugin * (*)()) dlsym(handle, "getPlugin");
-  if (!getPlugin) {
+  void* sym = lib.getAddressOfSymbol("getPlugin");
+  if (!sym) {
     metacg::MCGLogger::instance().getErrConsole()->error(
         "Could not load collectors from plugin, no Function \"getPlugin()\"!");
     return nullptr;
   }
-
+  auto getPlugin = reinterpret_cast<Plugin* (*)()>(sym);
   Plugin* loadedPlugin=getPlugin();
   metacg::MCGLogger::logInfo("Successfully loaded Plugin: {}", loadedPlugin->getPluginName());
   return loadedPlugin;


### PR DESCRIPTION
See title.

This brings CGC2's plugin interface implementation into line with CaGe's plugin implementation.