### PR TITLE
Only reiterate failure to create metadata for each node if log level is debug or finer

### DIFF
--- a/graph/include/metacg/metadata/MetaData.h
+++ b/graph/include/metacg/metadata/MetaData.h
@@ -30,7 +30,7 @@ class MCGManager;
  *  A class *must* implement a  static constexpr const char *key that contains the class
  *  name as a string. This is used for registration in the MetaData field of the CgNode.
  */
-template <class CRTPBase>
+template <class CRTPBase=void>
 class MetaDataFactory {
  public:
   template <class... T>
@@ -63,6 +63,22 @@ class MetaDataFactory {
   };
 
   friend CRTPBase;
+
+  /**
+ * Checks whether a metadatas key is registered
+ *
+ * @param metadataKey the key of the metadat to search for
+ * @return true if the key is known
+ */
+  static bool isRegistered(const std::string& metadataKey) {
+    for (const auto& [registeredMetadataName, _] : data()) {
+      if (registeredMetadataName == metadataKey)
+        return true;
+    }
+    return false;
+  }
+
+
 
  private:
   class Key {

--- a/graph/src/io/VersionFourMCGReader.cpp
+++ b/graph/src/io/VersionFourMCGReader.cpp
@@ -178,7 +178,10 @@ std::unique_ptr<metacg::Callgraph> metacg::io::VersionFourMCGReader::read() {
           if (auto md = metacg::MetaData::create<>(mdKey, mdValJ, strToNode); md) {
             cg->addEdgeMetaData({nodeData.nodeId, calleeNode->getId()}, std::move(md));
           } else {
-              errConsole->debug("Could not create edge metadata of type {} for edge {} to {}", mdKey, nodeData.nodeId, calleeNode->getId());
+            if (MetaDataFactory<>::isRegistered(mdKey)) {
+              errConsole->warn("Could not create edge metadata of type {} for edge {} to {}", mdKey, nodeData.nodeId,
+                                calleeNode->getId());
+            }
             if (failedMetadataCb) {
               (*failedMetadataCb)(nodeData.nodeId, mdKey, mdValJ);
             }
@@ -193,7 +196,9 @@ std::unique_ptr<metacg::Callgraph> metacg::io::VersionFourMCGReader::read() {
       if (auto md = metacg::MetaData::create<>(mdKey, mdVal, strToNode); md) {
         node->addMetaData(std::move(md));
       } else {
-          errConsole->debug("Could not create metadata of type {} for node {}", mdKey, node->getFunctionName());
+        if (MetaDataFactory<>::isRegistered(mdKey)) {
+          errConsole->warn("Could not create metadata of type {} for node {}", mdKey, node->getFunctionName());
+        }
         if (failedMetadataCb) {
           (*failedMetadataCb)(node->getId(), mdKey, mdVal);
         }
@@ -209,7 +214,9 @@ std::unique_ptr<metacg::Callgraph> metacg::io::VersionFourMCGReader::read() {
     if (auto md = metacg::MetaData::create<>(mdKey, mdValJ, strToNode); md) {
       cg->addMetaData(std::move(md));
     } else {
-        errConsole->debug("Could not create global metadata of type {}", mdKey);
+      if (MetaDataFactory<>::isRegistered(mdKey)) {
+        errConsole->warn("Could not create global metadata of type {}", mdKey);
+      }
       if (failedMetadataCb) {
         (*failedMetadataCb)(std::nullopt, mdKey, mdValJ);
       }

--- a/graph/src/io/VersionFourMCGReader.cpp
+++ b/graph/src/io/VersionFourMCGReader.cpp
@@ -9,7 +9,6 @@
 #include "metacg/Timing.h"
 #include "metacg/Util.h"
 #include "metacg/metadata/BuiltinMD.h"
-#include <iostream>
 
 using namespace metacg;
 

--- a/graph/src/io/VersionFourMCGReader.cpp
+++ b/graph/src/io/VersionFourMCGReader.cpp
@@ -102,7 +102,6 @@ std::unique_ptr<metacg::Callgraph> metacg::io::VersionFourMCGReader::read() {
   const MCGFileFormatInfo ffInfo{4, 0};
   auto console = metacg::MCGLogger::instance().getConsole();
   auto errConsole = metacg::MCGLogger::instance().getErrConsole();
-
   auto j = source.get();
   auto mcgInfo = j[ffInfo.metaInfoFieldName];
   if (mcgInfo.is_null()) {
@@ -179,9 +178,7 @@ std::unique_ptr<metacg::Callgraph> metacg::io::VersionFourMCGReader::read() {
           if (auto md = metacg::MetaData::create<>(mdKey, mdValJ, strToNode); md) {
             cg->addEdgeMetaData({nodeData.nodeId, calleeNode->getId()}, std::move(md));
           } else {
-            if (spdlog::get_level() <= spdlog::level::debug) {
-              errConsole->warn("Could not create edge metadata of type {} for edge {} to {}", mdKey, nodeData.nodeId, calleeNode->getId());
-            }
+              errConsole->debug("Could not create edge metadata of type {} for edge {} to {}", mdKey, nodeData.nodeId, calleeNode->getId());
             if (failedMetadataCb) {
               (*failedMetadataCb)(nodeData.nodeId, mdKey, mdValJ);
             }
@@ -196,9 +193,7 @@ std::unique_ptr<metacg::Callgraph> metacg::io::VersionFourMCGReader::read() {
       if (auto md = metacg::MetaData::create<>(mdKey, mdVal, strToNode); md) {
         node->addMetaData(std::move(md));
       } else {
-        if (spdlog::get_level() <= spdlog::level::debug) {
-          errConsole->warn("Could not create metadata of type {} for node {}", mdKey, node->getFunctionName());
-        }
+          errConsole->debug("Could not create metadata of type {} for node {}", mdKey, node->getFunctionName());
         if (failedMetadataCb) {
           (*failedMetadataCb)(node->getId(), mdKey, mdVal);
         }
@@ -214,9 +209,7 @@ std::unique_ptr<metacg::Callgraph> metacg::io::VersionFourMCGReader::read() {
     if (auto md = metacg::MetaData::create<>(mdKey, mdValJ, strToNode); md) {
       cg->addMetaData(std::move(md));
     } else {
-      if (spdlog::get_level() <= spdlog::level::debug) {
-        errConsole->warn("Could not create global metadata of type {}", mdKey);
-      }
+        errConsole->debug("Could not create global metadata of type {}", mdKey);
       if (failedMetadataCb) {
         (*failedMetadataCb)(std::nullopt, mdKey, mdValJ);
       }

--- a/graph/src/io/VersionFourMCGReader.cpp
+++ b/graph/src/io/VersionFourMCGReader.cpp
@@ -179,8 +179,13 @@ std::unique_ptr<metacg::Callgraph> metacg::io::VersionFourMCGReader::read() {
           auto& mdValJ = mdElem.value();
           if (auto md = metacg::MetaData::create<>(mdKey, mdValJ, strToNode); md) {
             cg->addEdgeMetaData({nodeData.nodeId, calleeNode->getId()}, std::move(md));
-          } else if (failedMetadataCb) {
-            (*failedMetadataCb)(nodeData.nodeId, mdKey, mdValJ);
+          } else {
+            if (spdlog::get_level() <= spdlog::level::debug) {
+              errConsole->warn("Could not create edge metadata of type {} for edge {} to {}", mdKey, nodeData.nodeId, calleeNode->getId());
+            }
+            if (failedMetadataCb) {
+              (*failedMetadataCb)(nodeData.nodeId, mdKey, mdValJ);
+            }
           }
         }
       }
@@ -192,7 +197,9 @@ std::unique_ptr<metacg::Callgraph> metacg::io::VersionFourMCGReader::read() {
       if (auto md = metacg::MetaData::create<>(mdKey, mdVal, strToNode); md) {
         node->addMetaData(std::move(md));
       } else {
-        errConsole->warn("Could not create metadata of type {} for node {}", mdKey, node->getFunctionName());
+        if (spdlog::get_level() <= spdlog::level::debug) {
+          errConsole->warn("Could not create metadata of type {} for node {}", mdKey, node->getFunctionName());
+        }
         if (failedMetadataCb) {
           (*failedMetadataCb)(node->getId(), mdKey, mdVal);
         }
@@ -208,7 +215,9 @@ std::unique_ptr<metacg::Callgraph> metacg::io::VersionFourMCGReader::read() {
     if (auto md = metacg::MetaData::create<>(mdKey, mdValJ, strToNode); md) {
       cg->addMetaData(std::move(md));
     } else {
-      errConsole->warn("Could not create global metadata of type {}", mdKey);
+      if (spdlog::get_level() <= spdlog::level::debug) {
+        errConsole->warn("Could not create global metadata of type {}", mdKey);
+      }
       if (failedMetadataCb) {
         (*failedMetadataCb)(std::nullopt, mdKey, mdValJ);
       }


### PR DESCRIPTION
When looking in the logs of our container build, I found that

1. After logging that we can not create "SomeMetadata", we additionally log that we can not create "SomeMetadata" for each node it was attached to. While I see how this could be helpful for debugging failure to create Metadata on certain nodes, I propose to limit the logging per node to debug or trace logging granularity

2. We did not log this failure for edge-based metadata, only for node and global metadata. I unified this behavior.
