### PR TITLE
Fix Downstream CI

### DIFF
--- a/.ci/gitlab/.gitlab-ci.yml
+++ b/.ci/gitlab/.gitlab-ci.yml
@@ -318,8 +318,8 @@ CGC2Plugin-test:
     - export BUILD=$(realpath $BUILD)
     - export INSTALL=$(realpath $INSTALL)
     - cd tools/cgcollector2/CGC2DemoPlugin
-    - CMAKE_PREFIX_PATH=$INSTALL/lib64/cmake/metacg cmake -S . -B $BUILD-install-test
-    - cmake --build $BUILD-install-test --parallel
+    - CMAKE_PREFIX_PATH=$INSTALL/lib64/cmake/metacg cmake -S . -B $BUILD-install-test-cgc2
+    - cmake --build $BUILD-install-test-cgc2 --parallel
 
 CaGePlugin-test:
   <<: *job-setup
@@ -329,5 +329,5 @@ CaGePlugin-test:
     - export BUILD=$(realpath $BUILD)
     - export INSTALL=$(realpath $INSTALL)
     - cd tools/cage/CaGeDemoPlugin
-    - CMAKE_PREFIX_PATH=$INSTALL/lib64/cmake/metacg cmake -S . -B $BUILD-install-test
-    - cmake --build $BUILD-install-test --parallel
+    - CMAKE_PREFIX_PATH=$INSTALL/lib64/cmake/metacg cmake -S . -B $BUILD-install-test-cage
+    - cmake --build $BUILD-install-test-cage --parallel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ if(METACG_BUILD_GRAPH_TOOLS)
   # Determine if we can build CaGe
   if(${LLVM_PACKAGE_VERSION}
      GREATER
-     15
+     14
   )
     set(BUILD_CAGE ON)
 

--- a/tools/cage/CaGeDemoPlugin/CMakeLists.txt
+++ b/tools/cage/CaGeDemoPlugin/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.16)
 project(CaGeDemoPlugin)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 find_package(metacg REQUIRED)
 
 if(metacg_FOUND)

--- a/tools/cgcollector2/CGC2DemoPlugin/CMakeLists.txt
+++ b/tools/cgcollector2/CGC2DemoPlugin/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.16)
 project(CGC2DemoPlugin)
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 find_package(metacg REQUIRED)
 
 if(metacg_FOUND)


### PR DESCRIPTION
The downstream CI was red since PR #138.
This PR fixes the misconfiguration in the build directories, as well as adds compatibility with LLVM/Clang 15, as this version is part of the downstream CI's compatibility matrix.
