### PR TITLE
[NFC, pymetacg] Use Python_SITEARCH for default installation path

### DIFF
--- a/pymetacg/CMakeLists.txt
+++ b/pymetacg/CMakeLists.txt
@@ -18,9 +18,7 @@ nanobind_disable_stack_protector(pymetacg)
 add_metacg_library(pymetacg)
 
 if(NOT CMAKE_INSTALL_PYTHON_LIBDIR)
-  set(CMAKE_INSTALL_PYTHON_LIBDIR
-      "${CMAKE_INSTALL_LIBDIR}/python${Python_VERSION_MAJOR}.${Python_VERSION_MINOR}/site-packages"
-  )
+  set(CMAKE_INSTALL_PYTHON_LIBDIR ${Python_SITEARCH})
 endif()
 
 install(TARGETS pymetacg DESTINATION ${CMAKE_INSTALL_PYTHON_LIBDIR})


### PR DESCRIPTION
I just stumbled over `Python_SITEARCH` which is populated by `find_package(Python)`. This makes it easier to set the default install directory for pymetacg without weird path construction we used before.