### PR TITLE
[FIX] Adds compatibility for LLVM-22 

### DIFF
--- a/cgcollector/lib/include/AliasAnalysis.h
+++ b/cgcollector/lib/include/AliasAnalysis.h
@@ -474,7 +474,11 @@ class ASTInformationExtractor : public clang::RecursiveASTVisitor<ASTInformation
   bool TraverseCXXNoexceptExpr(clang::CXXNoexceptExpr*, [[maybe_unused]] DataRecursionQueue* Queue = nullptr);
 
   // Extracted from the recursive ast visitor because by default it always visits noexcept specifiers
-  bool TraverseFunctionProtoTypeLoc(clang::FunctionProtoTypeLoc TL);
+#if LLVM_VERSION_MAJOR >= 22
+  bool TraverseFunctionProtoTypeLoc(clang::FunctionProtoTypeLoc TL,  [[maybe_unused]] bool TraverseQualifier=true);
+#else
+  bool TraverseFunctionProtoTypeLoc(clang::FunctionProtoTypeLoc TL)
+#endif
 
   /**
    * We only use this to prevent traversing of types in  a function body
@@ -490,7 +494,12 @@ class ASTInformationExtractor : public clang::RecursiveASTVisitor<ASTInformation
   bool VisitRecordType(clang::RecordType* RT);
 
   // bool TraverseTypeDecl(clang::TypeDecl *TD);
+#if LLVM_VERSION_MAJOR >= 22
+  bool TraverseTypeLoc(clang::TypeLoc TL, [[maybe_unused]] bool TraverseQualifier=true);
+#else
   bool TraverseTypeLoc(clang::TypeLoc TL);
+#endif
+
   bool TraverseRecordDecl(clang::RecordDecl* RD);
   bool TraverseCXXRecordDecl(clang::CXXRecordDecl* RD);
 

--- a/cgcollector/lib/include/AliasAnalysis.h
+++ b/cgcollector/lib/include/AliasAnalysis.h
@@ -477,7 +477,7 @@ class ASTInformationExtractor : public clang::RecursiveASTVisitor<ASTInformation
 #if LLVM_VERSION_MAJOR >= 22
   bool TraverseFunctionProtoTypeLoc(clang::FunctionProtoTypeLoc TL,  [[maybe_unused]] bool TraverseQualifier=true);
 #else
-  bool TraverseFunctionProtoTypeLoc(clang::FunctionProtoTypeLoc TL)
+  bool TraverseFunctionProtoTypeLoc(clang::FunctionProtoTypeLoc TL);
 #endif
 
   /**

--- a/cgcollector/lib/src/AliasAnalysis.cpp
+++ b/cgcollector/lib/src/AliasAnalysis.cpp
@@ -657,7 +657,7 @@ bool ASTInformationExtractor::TraverseParmVarDecl(clang::ParmVarDecl* PD) {
   return Ret;
 }
 
-#if LLVM_VERSION_MAJOR>= 22
+#if LLVM_VERSION_MAJOR >= 22
 bool ASTInformationExtractor::TraverseTypeLoc(clang::TypeLoc TL, bool TraverseQualifier ) {
 #else
 bool ASTInformationExtractor::TraverseTypeLoc(clang::TypeLoc TL) {
@@ -665,7 +665,7 @@ bool ASTInformationExtractor::TraverseTypeLoc(clang::TypeLoc TL) {
   if (!TraverseTypeLocs) {
     return true;
   }
-#if LLVM_VERSION_MAJOR>= 22
+#if LLVM_VERSION_MAJOR >= 22
   return RecursiveASTVisitor::TraverseTypeLoc(TL,TraverseQualifier);
 #else
   return RecursiveASTVisitor::TraverseTypeLoc(TL);

--- a/cgcollector/lib/src/AliasAnalysis.cpp
+++ b/cgcollector/lib/src/AliasAnalysis.cpp
@@ -658,7 +658,7 @@ bool ASTInformationExtractor::TraverseParmVarDecl(clang::ParmVarDecl* PD) {
 }
 
 #if LLVM_VERSION_MAJOR >= 22
-bool ASTInformationExtractor::TraverseTypeLoc(clang::TypeLoc TL, bool TraverseQualifier ) {
+bool ASTInformationExtractor::TraverseTypeLoc(clang::TypeLoc TL, [[maybe_unused]] bool TraverseQualifier ) {
 #else
 bool ASTInformationExtractor::TraverseTypeLoc(clang::TypeLoc TL) {
 #endif
@@ -666,7 +666,7 @@ bool ASTInformationExtractor::TraverseTypeLoc(clang::TypeLoc TL) {
     return true;
   }
 #if LLVM_VERSION_MAJOR >= 22
-  return RecursiveASTVisitor::TraverseTypeLoc(TL,TraverseQualifier);
+  return RecursiveASTVisitor::TraverseTypeLoc(TL, TraverseQualifier);
 #else
   return RecursiveASTVisitor::TraverseTypeLoc(TL);
 #endif
@@ -996,8 +996,8 @@ bool ASTInformationExtractor::VisitRecordType(clang::RecordType* RT) {
 bool ASTInformationExtractor::TraverseCXXNoexceptExpr(clang::CXXNoexceptExpr*, DataRecursionQueue*) { return true; }
 
 // This is the expanded code from clangs AST visitor, modified to skip exception specifieres and similar
-#if LLVM_VERSION_MAJOR>= 22
-bool ASTInformationExtractor::TraverseFunctionProtoTypeLoc(clang::FunctionProtoTypeLoc TL,[[maybe_unused]] bool TraverseQualifier) {
+#if LLVM_VERSION_MAJOR >= 22
+bool ASTInformationExtractor::TraverseFunctionProtoTypeLoc(clang::FunctionProtoTypeLoc TL, [[maybe_unused]] bool TraverseQualifier) {
 #else
 bool ASTInformationExtractor::TraverseFunctionProtoTypeLoc(clang::FunctionProtoTypeLoc TL) {
 #endif

--- a/cgcollector/lib/src/AliasAnalysis.cpp
+++ b/cgcollector/lib/src/AliasAnalysis.cpp
@@ -657,11 +657,19 @@ bool ASTInformationExtractor::TraverseParmVarDecl(clang::ParmVarDecl* PD) {
   return Ret;
 }
 
+#if LLVM_VERSION_MAJOR>= 22
+bool ASTInformationExtractor::TraverseTypeLoc(clang::TypeLoc TL, bool TraverseQualifier ) {
+#else
 bool ASTInformationExtractor::TraverseTypeLoc(clang::TypeLoc TL) {
+#endif
   if (!TraverseTypeLocs) {
     return true;
   }
+#if LLVM_VERSION_MAJOR>= 22
+  return RecursiveASTVisitor::TraverseTypeLoc(TL,TraverseQualifier);
+#else
   return RecursiveASTVisitor::TraverseTypeLoc(TL);
+#endif
 }
 
 bool ASTInformationExtractor::TraverseCXXMethodDecl(clang::CXXMethodDecl* MD) {
@@ -988,7 +996,11 @@ bool ASTInformationExtractor::VisitRecordType(clang::RecordType* RT) {
 bool ASTInformationExtractor::TraverseCXXNoexceptExpr(clang::CXXNoexceptExpr*, DataRecursionQueue*) { return true; }
 
 // This is the expanded code from clangs AST visitor, modified to skip exception specifieres and similar
+#if LLVM_VERSION_MAJOR>= 22
+bool ASTInformationExtractor::TraverseFunctionProtoTypeLoc(clang::FunctionProtoTypeLoc TL,[[maybe_unused]] bool TraverseQualifier) {
+#else
 bool ASTInformationExtractor::TraverseFunctionProtoTypeLoc(clang::FunctionProtoTypeLoc TL) {
+#endif
   if (!getDerived().shouldTraversePostOrder()) {
     if (!getDerived().WalkUpFromFunctionProtoTypeLoc(TL))
       return false;

--- a/tools/cage/include/cage/CaGe.h
+++ b/tools/cage/include/cage/CaGe.h
@@ -8,7 +8,11 @@
 
 #include "llvm/Pass.h"
 #include "llvm/Passes/PassBuilder.h"
+#if LLVM_VERSION_MAJOR >= 22
+#include "llvm/Plugins/PassPlugin.h"
+#else
 #include "llvm/Passes/PassPlugin.h"
+#endif
 
 namespace cage {
 

--- a/tools/cage/src/CaGe.cpp
+++ b/tools/cage/src/CaGe.cpp
@@ -6,9 +6,6 @@
 #include "cage/CaGe.h"
 #include "cage/interface/CaGePlugin.h"
 
-#include "llvm/Passes/PassBuilder.h"
-#include "llvm/Passes/PassPlugin.h"
-
 #include "cage/generator/CallgraphGenerator.h"
 #include "cage/generator/FileExporter.h"
 

--- a/tools/cgpatch/src/CGPatchInstPass.cpp
+++ b/tools/cgpatch/src/CGPatchInstPass.cpp
@@ -11,7 +11,11 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Passes/PassBuilder.h"
+#if LLVM_VERSION_MAJOR >= 22
+#include "llvm/Plugins/PassPlugin.h"
+#else
 #include "llvm/Passes/PassPlugin.h"
+#endif
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/raw_ostream.h"


### PR DESCRIPTION
In LLVM-22 two of the type traversal functions got a new parameter, whether to traverse qualifiers.

We do not care about the qualifiers, so we just need to pass them along.
This PR uses macros to define the correct function and pass the qualifiers accordingly if available.

This should address #145.
 