### PR TITLE
[CI] Symlink flang to flang-new if flang is not in the PATH

### DIFF
--- a/.ci/gitlab/spack/prepare.sh
+++ b/.ci/gitlab/spack/prepare.sh
@@ -14,4 +14,11 @@ spack python ${SCRIPT_DIR}/check_spack_env.py || exit 1
 
 spack env view regenerate || exit 1
 
+# symlink flang to flang-new if flang is not in the PATH
+if ! command -v flang &>/dev/null; then
+    flang_new=$(command -v flang-new) || { echo "flang-new not found in PATH"; exit 1; }
+    ln -s "$flang_new" "$(dirname "$flang_new")/flang"
+    echo "Created symlink: $(dirname "$flang_new")/flang -> $flang_new"
+fi
+
 exit 0


### PR DESCRIPTION
This is to fix the downstream CI test failures for cgfcollector.

CC @gomfol12 