### PR TITLE
[Gitlab CI] Fix Spack installation status detection

### DIFF
--- a/.ci/gitlab/spack/check_spack_env.py
+++ b/.ci/gitlab/spack/check_spack_env.py
@@ -51,7 +51,7 @@ def check_environment_installed():
     # Check installation status of each spec
     for spec in all_specs:
         # Check if the spec is installed
-        if spec.installed:
+        if spec.installed or spec.external:
             installed_specs.append(spec)
             # Check if this is an external package
             # External packages can be detected via spec.external or spec.external_path


### PR DESCRIPTION
This patches the Python script that checks whether all the compilers and dependencies are installed (via Spack). Apparently, an update to Spack slightly changed the API there.